### PR TITLE
Generate tests directory and placeholder test

### DIFF
--- a/src/aac/genplug.py
+++ b/src/aac/genplug.py
@@ -108,6 +108,7 @@ def _compile_templates(parsed_models: dict[str, dict]) -> dict[str, list[Templat
 
     # Define which templates we want to overwrite.
     templates_to_overwrite = ["plugin.py.jinja2", "setup.py.jinja2"]
+    template_parent_directories = {"test_plugin_impl.py.jinja2": "tests"}
 
     def set_overwrite_value(template: TemplateOutputFile):
         template.overwrite = template.template_name in templates_to_overwrite
@@ -116,6 +117,10 @@ def _compile_templates(parsed_models: dict[str, dict]) -> dict[str, list[Templat
         template.file_name = _convert_template_name_to_file_name(
             template.template_name, plugin_implementation_name
         )
+
+    def set_parent_directory_value(template: TemplateOutputFile):
+        if template.template_name in template_parent_directories:
+            template.parent_dir = template_parent_directories[template.template_name]
 
     # ensure model is present and valid, get the plugin name
     plugin_models = util.get_models_by_type(parsed_models, "model")
@@ -159,6 +164,7 @@ def _compile_templates(parsed_models: dict[str, dict]) -> dict[str, list[Templat
     for template in generated_templates.values():
         set_overwrite_value(template)
         set_filename_value(template)
+        set_parent_directory_value(template)
 
     return generated_templates
 

--- a/src/aac/genplug.py
+++ b/src/aac/genplug.py
@@ -119,8 +119,7 @@ def _compile_templates(parsed_models: dict[str, dict]) -> dict[str, list[Templat
         )
 
     def set_parent_directory_value(template: TemplateOutputFile):
-        if template.template_name in template_parent_directories:
-            template.parent_dir = template_parent_directories[template.template_name]
+        template.parent_dir = template_parent_directories.get(template.template_name) or template.parent_dir
 
     # ensure model is present and valid, get the plugin name
     plugin_models = util.get_models_by_type(parsed_models, "model")

--- a/src/aac/template_engine.py
+++ b/src/aac/template_engine.py
@@ -124,14 +124,16 @@ def write_generated_templates_to_file(
     _ensure_directory_exists(output_directory)
     for generated_file in generated_files:
         _write_file(
-            _full_output_directory(output_directory, generated_file),
+            _get_template_output_directory(output_directory, generated_file),
             generated_file.file_name,
             generated_file.content,
             generated_file.overwrite,
         )
 
 
-def _full_output_directory(output_directory: str, generated_file: TemplateOutputFile) -> str:
+def _get_template_output_directory(
+    output_directory: str, generated_file: TemplateOutputFile
+) -> str:
     def _should_output_to_plugin_root_directory(output_file: TemplateOutputFile) -> bool:
         return output_file.parent_dir == "."
 

--- a/src/aac/template_engine.py
+++ b/src/aac/template_engine.py
@@ -132,11 +132,11 @@ def write_generated_templates_to_file(
 
 
 def _full_output_directory(output_directory: str, generated_file: TemplateOutputFile) -> str:
-    def _should_output_to_cwd(path: TemplateOutputFile) -> bool:
-        return path.parent_dir == "."
+    def _should_output_to_plugin_root_directory(output_file: TemplateOutputFile) -> bool:
+        return output_file.parent_dir == "."
 
     output_dir = output_directory
-    if not _should_output_to_cwd(generated_file):
+    if not _should_output_to_plugin_root_directory(generated_file):
         output_dir = os.path.join(output_directory, generated_file.parent_dir)
         _ensure_directory_exists(output_dir)
 
@@ -173,7 +173,7 @@ class TemplateOutputFile:
     Class containing all of the relevant information necessary to handle writing templates to files.
 
     Attributes:
-        parent_dir (str): The directory in which to generate the file (defaults to the current directory).
+        parent_dir (str): The directory in which to generate the file (defaults to the plugin root directory).
         template_name (str): The name of the jinja2 template the generated content is based on
         content (str): The generated content
         overwrite (bool): A boolean to indicate if this template output should overwrite any existing files with the same name.

--- a/src/aac/templates/genplug/test_plugin_impl.py.jinja2
+++ b/src/aac/templates/genplug/test_plugin_impl.py.jinja2
@@ -1,0 +1,8 @@
+from unittest import TestCase
+
+from {{plugin.implementation_name}}_impl import *
+
+class Test{{plugin.name | title | replace('-', '')}}(TestCase):
+    def test(self):
+        # TODO: Write tests for {{plugin.name}}
+        self.assertTrue(False)

--- a/tests/test_template_engine.py
+++ b/tests/test_template_engine.py
@@ -83,3 +83,25 @@ class TestTemplateEngine(TestCase):
 
                 with open(os.path.join(temp_directory, expected_template.file_name)) as file:
                     self.assertEqual(expected_template.content, file.read())
+
+    def test_write_generated_templates_to_file_in_directory(self):
+        test_template = TemplateOutputFile(
+            "template.test", "The sample content.", False, parent_dir="tests"
+        )
+        test_template.file_name = "temp"
+
+        self.assertIsNotNone(test_template)
+        self.assertEqual(test_template.file_name, "temp")
+        self.assertEqual(test_template.parent_dir, "tests")
+
+        with TemporaryDirectory() as temp_dir:
+            write_generated_templates_to_file([test_template], temp_dir)
+            temp_dir_files = os.listdir(temp_dir)
+            print(temp_dir_files)
+
+            self.assertEqual(len(temp_dir_files), 1)
+            self.assertIn(test_template.parent_dir, temp_dir_files)
+
+            test_file = os.path.join(temp_dir, test_template.parent_dir, test_template.file_name)
+            with open(test_file) as file:
+                self.assertEqual(test_template.content, file.read())

--- a/tests/test_template_engine.py
+++ b/tests/test_template_engine.py
@@ -97,7 +97,6 @@ class TestTemplateEngine(TestCase):
         with TemporaryDirectory() as temp_dir:
             write_generated_templates_to_file([test_template], temp_dir)
             temp_dir_files = os.listdir(temp_dir)
-            print(temp_dir_files)
 
             self.assertEqual(len(temp_dir_files), 1)
             self.assertIn(test_template.parent_dir, temp_dir_files)


### PR DESCRIPTION
Changes:

- Add `parent_dir` attribute to `TemplateOutputFile` so we can generate files to
  sub-directories of the `output_directory`.
- Update `genplug.py` to generate a `tests/` directory with a test stub that will need to be implemented.