### PR TITLE
I want Genplugin to generate a README file

### DIFF
--- a/src/aac/genplug.py
+++ b/src/aac/genplug.py
@@ -179,17 +179,7 @@ def _convert_template_name_to_file_name(template_name: str, plugin_name: str) ->
         A string containing the personalized/pythonic file name.
     """
 
-    #  we're using that genplug will only ever generate python templates
-    assumed_file_extension = ".py"
-
-    #  Strip anything after the .py ending
-    strip_index = template_name.index(assumed_file_extension) + len(assumed_file_extension)
-    file_name = template_name[:strip_index]
-
-    # Replace "plugin" with the plugin name
-    file_name = file_name.replace("plugin", plugin_name)
-
-    return file_name
+    return template_name.replace(".jinja2", "").replace("plugin", plugin_name)
 
 
 def _is_user_desired_output_directory(architecture_file: str, output_dir: str) -> bool:

--- a/src/aac/templates/genplug/README.md.jinja2
+++ b/src/aac/templates/genplug/README.md.jinja2
@@ -2,16 +2,21 @@
 
 ## Plugin Commands
 
-### Shell Command
+{%- for command in commands %}
+
+### Command: {{command.name}}
+
+{{command.description}}
+
+Example shell usage:
 
 ```bash
-(.env) $ aac {{plugin.name}}
+(.env) $ aac {{command.name}} -h
 ```
 
-### Command arguments
+#### Command arguments
 
-- `-h, --help`: Shows a help message
-{%- for command in commands %}
+- `-h`, `--help`: Shows a help message
 {%- if command.input is defined %}
 {%- for command_input in command.input %}
 - `{{command_input.name}}`: {% if command_input.description is defined %}{{command_input.description}}{% else %}TODO: add description{%- endif %}

--- a/src/aac/templates/genplug/README.md.jinja2
+++ b/src/aac/templates/genplug/README.md.jinja2
@@ -1,0 +1,34 @@
+# {{plugin.name}}
+
+## Plugin Commands
+
+### Shell Command
+
+```bash
+(.env) $ aac {{plugin.name}}
+```
+
+### Command arguments
+
+- `-h, --help`: Shows a help message
+{%- for command in commands %}
+{%- if command.input is defined %}
+{%- for command_input in command.input %}
+- `{{command_input.name}}`: {% if command_input.description is defined %}{{command_input.description}}{% else %}TODO: add description{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- endfor %}
+
+## Plugin Extensions and Definitions
+
+{%- for def in aac_definitions %}
+{%- set type = def | rejectattr('yaml') | list | first %}
+
+### {{type | title}} - {{def[type].name}}
+
+TODO: Add descriptive information about {{def[type].name}}
+
+```yaml
+{{def.yaml}}
+```
+{%- endfor %}

--- a/src/aac/templates/genplug/README.md.jinja2
+++ b/src/aac/templates/genplug/README.md.jinja2
@@ -24,6 +24,8 @@ Example shell usage:
 {%- endif %}
 {%- endfor %}
 
+{%- if aac_definitions | length > 0 %}
+
 ## Plugin Extensions and Definitions
 
 {%- for def in aac_definitions %}
@@ -37,3 +39,4 @@ TODO: Add descriptive information about {{def[type].name}}
 {{def.yaml}}
 ```
 {%- endfor %}
+{%- endif %}

--- a/tests/test_genplug.py
+++ b/tests/test_genplug.py
@@ -12,6 +12,7 @@ PLUGIN_TEMPLATE_NAME = "plugin.py.jinja2"
 PLUGIN_IMPL_TEMPLATE_NAME = "plugin_impl.py.jinja2"
 PLUGIN_IMPL_TEST_TEMPLATE_NAME = "test_plugin_impl.py.jinja2"
 SETUP_TEMPLATE_NAME = "setup.py.jinja2"
+README_TEMPLATE_NAME = "README.md.jinja2"
 
 
 class TestGenPlug(TestCase):
@@ -59,6 +60,7 @@ class TestGenPlug(TestCase):
         # Assert that the expected template files were generated
         self.assertIn("__init__.py", generated_template_names)
         self.assertIn("setup.py", generated_template_names)
+        self.assertIn("README.md", generated_template_names)
         self.assertIn(f"{plugin_name}.py", generated_template_names)
         self.assertIn(f"{plugin_name}_impl.py", generated_template_names)
         self.assertIn(f"test_{plugin_name}_impl.py", generated_template_names)
@@ -93,6 +95,14 @@ class TestGenPlug(TestCase):
         ).parent_dir
         self.assertEqual(generated_plugin_impl_test_file_parent_dir, "tests")
 
+        generated_readme_file_contents = generated_templates.get(README_TEMPLATE_NAME).content
+        self.assertIn("# aac-gen-protobuf", generated_readme_file_contents)
+        self.assertIn("## Plugin Commands", generated_readme_file_contents)
+        self.assertIn("## Plugin Extensions and Definitions", generated_readme_file_contents)
+        self.assertIn("$ aac aac-gen-protobuf", generated_readme_file_contents)
+        self.assertIn("### Ext", generated_readme_file_contents)
+        self.assertIn("### Enum", generated_readme_file_contents)
+
     def test__compile_templates_errors_on_multiple_models(self):
         parsed_model = parser.parse_str(
             f"{TEST_PLUGIN_YAML_STRING}\n---\n{SECONDARY_MODEL_YAML_DEFINITION}", "", True
@@ -123,6 +133,7 @@ class TestGenPlug(TestCase):
 
         self.assertIn("__init__.py", generated_template_names)
         self.assertIn("setup.py", generated_template_names)
+        self.assertIn("README.md", generated_template_names)
         self.assertIn(f"{plugin_name}.py", generated_template_names)
         self.assertIn(f"{plugin_name}_impl.py", generated_template_names)
         self.assertIn(f"test_{plugin_name}_impl.py", generated_template_names)

--- a/tests/test_genplug.py
+++ b/tests/test_genplug.py
@@ -97,9 +97,9 @@ class TestGenPlug(TestCase):
 
         generated_readme_file_contents = generated_templates.get(README_TEMPLATE_NAME).content
         self.assertIn("# aac-gen-protobuf", generated_readme_file_contents)
-        self.assertIn("## Plugin Commands", generated_readme_file_contents)
+        self.assertIn("## Command:", generated_readme_file_contents)
         self.assertIn("## Plugin Extensions and Definitions", generated_readme_file_contents)
-        self.assertIn("$ aac aac-gen-protobuf", generated_readme_file_contents)
+        self.assertIn("$ aac gen-protobuf", generated_readme_file_contents)
         self.assertIn("### Ext", generated_readme_file_contents)
         self.assertIn("### Enum", generated_readme_file_contents)
 


### PR DESCRIPTION
As a plugin developer, I want Genplugin to generate an initial README so that I have a consistent outline and starting point for my plugin's README file.

AC:


- [x] Genplugin generates a README.md file
- [x] The README.md file is not overwritten if it already exists
- [x] The README should include as much information from the plugin's model as possible:
  - [x] Plugin Name
  - [x] Plugin commands + descriptions
  - [x] Plugin-defined definitions that aren't the plugin model (enum, data, extensions, etc)

Changes:

- Update `genplug.py` to not assume we're only generating python files.
- Add a `README.md` Jinja2 template that gets generated when a new plugin is created.