### PR TITLE
Add Python types for GenPlugin Model Inputs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,6 +43,7 @@ jobs:
           path: html_code_coverage/
       - name: Validate Core Spec and Plugin Specs
         run: |
+          source venv/bin/activate
           find . -name AaC.yaml -exec aac validate {} \;
           find plugins -name *.yaml -exec aac validate {} \;
       - name: Generate API Documentation

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -41,6 +41,10 @@ jobs:
         with:
           name: test-coverage-report
           path: html_code_coverage/
+      - name: Validate Core Spec and Plugin Specs
+        run: |
+          find . -name AaC.yaml -exec aac validate {} \;
+          find plugins -name *.yaml -exec aac validate {} \;
       - name: Generate API Documentation
         run: |
           source venv/bin/activate

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,7 +44,7 @@
             "program": "src/aac/__main__.py",
             "args": [
                 "validate",
-                "./plugins/aac-gen-protobuf/aac-gen-protobuf.yaml"
+                "./plugins/gen-protobuf/aac-gen-protobuf.yaml"
             ],
             "console": "integratedTerminal",
             "justMyCode": false

--- a/plugins/aac-plantuml/aac-plantuml.yaml
+++ b/plugins/aac-plantuml/aac-plantuml.yaml
@@ -8,6 +8,7 @@ model:
       input:
         - name: architecture_file
           type: string
+          python_type: str
           description: Path to a yaml file containing an AaC usecase from which to generate a Plant UML component diagram.
       acceptance:
         - scenario: Output PlantUML component diagram for valid architecture.
@@ -23,6 +24,7 @@ model:
       input:
         - name: architecture_file
           type: string
+          python_type: str
           description: Path to a yaml file containing an AaC usecase from which to generate a Plant UML sequence diagram.
       acceptance:
         - scenario: Output PlantUML sequence diagram for valid use case.
@@ -38,6 +40,7 @@ model:
       input:
         - name: architecture_file
           type: string
+          python_type: str
           description: Path to a yaml file containing an AaC usecase from which to generate a Plant UML object diagram.
       acceptance:
         - scenario: Output PlantUML object diagram for valid model.

--- a/plugins/aac-spec/aac-spec.yaml
+++ b/plugins/aac-spec/aac-spec.yaml
@@ -97,8 +97,10 @@ model:
       input:
         - name: architecture_file
           type: file
+          python_type: str
         - name: parsed_model
           type: map
+          python_type: dict
       acceptance:
         - scenario: Valid spec traces are modeled.
           given:

--- a/plugins/gen-design-doc/aac-gen-design-doc.yaml
+++ b/plugins/gen-design-doc/aac-gen-design-doc.yaml
@@ -8,12 +8,15 @@ model:
       input:
         - name: architecture_files
           type: string
+          python_type: str
           description: A comma-separated list of yaml file(s) containing the modeled system for which to generate the System Design document.
         - name: output_directory
           type: string
+          python_type: str
           description: The directory to which the System Design document will be written.
         - name: --template_file
           type: string
+          python_type: str
           description: The name of the Jinja2 template file to use for generating the document. (optional)
       acceptance:
         - scenario: Output a System Design document containing an outline of the model and its components.

--- a/plugins/gen-gherkin-behaviors/aac-gen-gherkin-behaviors.yaml
+++ b/plugins/gen-gherkin-behaviors/aac-gen-gherkin-behaviors.yaml
@@ -8,9 +8,11 @@ model:
       input:
         - name: architecture_file
           type: string
+          python_type: str
           description: The yaml file containing the data models to generate as Gherkin feature files.
         - name: output_directory
           type: string
+          python_type: str
           description: The directory to write the generated Gherkin feature files to.
       acceptance:
         - scenario: Output Gherkin feature files for behavior scenarios in an Architecture model.

--- a/plugins/gen-protobuf/aac-gen-protobuf.yaml
+++ b/plugins/gen-protobuf/aac-gen-protobuf.yaml
@@ -8,9 +8,11 @@ model:
       input:
         - name: architecture_file
           type: string
+          python_type: str
           description: The yaml file containing the data models to generate as Protobuf messages.
         - name: output_directory
           type: string
+          python_type: str
           description: The directory to write the generated Protobuf messages to.
       acceptance:
         - scenario: Output protobuf messages for behavior input/output entries in an Architecture model.

--- a/src/aac/genplug.py
+++ b/src/aac/genplug.py
@@ -51,6 +51,33 @@ def get_base_model_extensions() -> str:
         string representing yaml extensions and data definitions employed by the plugin
     """
     return """
+---
+enum:
+  name: PythonDataType
+  values:
+    - str
+    - int
+    - float
+    - complex
+    - list
+    - tuple
+    - range
+    - dict
+    - set
+    - frozenset
+    - bool
+    - bytes
+    - bytearray
+    - memoryview
+---
+ext:
+   name: PythonTypeField
+   type: Field
+   dataExt:
+      add:
+        - name: python_type
+          type: PythonDataType
+---
 ext:
    name: CommandBehaviorType
    type: BehaviorType
@@ -264,3 +291,4 @@ def _add_definitions_yaml_string(model: dict) -> dict:
 
 def _convert_to_implementation_name(original_name: str) -> str:
     return original_name.replace("-", "_")
+

--- a/src/aac/genplug.py
+++ b/src/aac/genplug.py
@@ -255,12 +255,18 @@ def _gather_commands(behaviors: dict) -> list[dict]:
     Returns:
         list of command-type behaviors dicts
     """
+    def modify_command_input_output_entry(in_out_entry: dict):
+        """Modifies the input and output entries of a behavior definition to reduce complexity in the templates."""
+        in_out_entry["type"] = in_out_entry.get("python_type") or in_out_entry.get("type")
+
+        return in_out_entry
+
     commands = []
 
     for behavior in behaviors:
         behavior_name = behavior["name"]
         behavior_description = behavior["description"]
-        behavior_type = behavior["type"]
+        behavior_type = behavior.get("type")
 
         if behavior_type != "command":
             continue
@@ -268,6 +274,9 @@ def _gather_commands(behaviors: dict) -> list[dict]:
         # First line should end with a period. flake8(D400)
         if not behavior_description.endswith("."):
             behavior_description = f"{behavior_description}."
+
+        if behavior.get("input"):
+            behavior["input"] = list(map(modify_command_input_output_entry, behavior.get("input")))
 
         behavior["description"] = behavior_description
         behavior["implementation_name"] = _convert_to_implementation_name(behavior_name)

--- a/src/aac/templates/genplug/setup.py.jinja2
+++ b/src/aac/templates/genplug/setup.py.jinja2
@@ -5,6 +5,9 @@
 from setuptools import setup
 from {{plugin.implementation_name}}_impl import plugin_version
 
+with open("README.md", "r") as fh:
+    readme_description = fh.read()
+
 setup(
     version=plugin_version,
     name="{{plugin.name}}",

--- a/src/aac/validator.py
+++ b/src/aac/validator.py
@@ -142,9 +142,6 @@ def _get_all_errors_if_missing_required_properties(model: dict, required: list) 
 def _get_all_cross_reference_errors(kind: str, model: dict) -> iter:
     """Validate all cross references."""
 
-    data, enums = util.get_aac_spec()
-    models = {kind: model} | data | enums
-
     data = VALIDATOR_CONTEXT.get_all_data_definitions()
     enums = VALIDATOR_CONTEXT.get_all_enum_definitions()
     models = VALIDATOR_CONTEXT.get_all_model_definitions()
@@ -181,7 +178,7 @@ def _validate_data_references(data: dict) -> list:
 
 
 def _validate_model_references(models: list, data: dict) -> list:
-    """Ensure all references in sysetm models are valid."""
+    """Ensure all references in system models are valid."""
 
     def fn(name, spec):
         return _get_error_messages_if_invalid_type(
@@ -209,7 +206,7 @@ def _get_errors_if_model_references_bad_enum_value(
 ) -> list:
     """Return error messages for any enum value that is referenced but not recognized."""
 
-    def get_errors_for_bad_enum_in_model(model, paths):
+    def get_errors_for_bad_enum_in_model(model):
         errors = []
         for path in paths:
             errors += [
@@ -219,7 +216,7 @@ def _get_errors_if_model_references_bad_enum_value(
             ]
         return errors
 
-    return list(flatten(map(lambda m: get_errors_for_bad_enum_in_model(m, paths), models)))
+    return list(flatten(map(get_errors_for_bad_enum_in_model, models)))
 
 
 def _validate_enum_references(models: list, data: dict, enums: dict) -> list:
@@ -508,6 +505,7 @@ class ValidatorContext:
         Returns:
             A list of strings, one entry for each root name in the AaC model specification.
         """
+
         def get_field_name(fields_entry_dict: dict):
             return fields_entry_dict.get("name")
 

--- a/tests/test_genplug.py
+++ b/tests/test_genplug.py
@@ -77,8 +77,8 @@ class TestGenPlug(TestCase):
             PLUGIN_IMPL_TEMPLATE_NAME
         ).content
         self.assertIn("def gen_protobuf", generated_plugin_impl_file_contents)
-        self.assertIn("architecture_file", generated_plugin_impl_file_contents)
-        self.assertIn("output_directory", generated_plugin_impl_file_contents)
+        self.assertIn("architecture_file: str", generated_plugin_impl_file_contents)
+        self.assertIn("output_directory: string", generated_plugin_impl_file_contents)
         self.assertIn("raise NotImplementedError", generated_plugin_impl_file_contents)
 
         generated_plugin_impl_test_file_contents = generated_templates.get(
@@ -141,6 +141,7 @@ model:
       input:
         - name: architecture_file
           type: string
+          python_type: str
           description: The yaml file containing the data models to generate as Protobuf messages.
         - name: output_directory
           type: string


### PR DESCRIPTION
fixes #76 

New example output looks like this:
```python
"""AaC Plugin implementation module for the aac-gen-protobuf plugin."""
# NOTE: It is safe to edit this file.
# This file is only initially generated by the aac gen-plugin, and it won't be overwritten if the file already exists.

plugin_version = "0.0.1"


def gen_protobuf(architecture_file: str, output_directory: str):
    """
    Generate protobuf messages from Arch-as-Code models.

    Args:
        architecture_file (str): The yaml file containing the data models to generate as Protobuf messages.
        output_directory (str): The directory to write the generated Protobuf messages to.
    """

    # TODO add implementation here
    raise NotImplementedError("gen_protobuf is not implemented.")

```

Note that in the above example that we're outputting with the pythonic string types.