### PR TITLE
I want Genplugin to generate my plugin with a proper directory structure

### DIFF
--- a/src/aac/genplug.py
+++ b/src/aac/genplug.py
@@ -165,6 +165,12 @@ def _compile_templates(parsed_models: dict[str, dict]) -> dict[str, list[Templat
 
     plugin_implementation_name = _convert_to_implementation_name(plugin_name)
 
+    template_parent_directories = template_parent_directories | {
+        "plugin.py.jinja2": plugin_name,
+        "plugin_impl.py.jinja2": plugin_name,
+        "__init__.py.jinja2": plugin_name,
+    }
+
     # Prepare template variables/properties
     behaviors = util.search(plugin_model, ["behavior"])
     commands = _gather_commands(behaviors)

--- a/src/aac/genplug.py
+++ b/src/aac/genplug.py
@@ -124,7 +124,7 @@ def _compile_templates(parsed_models: dict[str, dict]) -> dict[str, list[Templat
     Parse the model and generate the plugin template accordingly.
 
     Args:
-        parsed_models: Dict representing the plugin models
+        parsed_models (dict[str, dict]): Dict representing the plugin models
 
     Returns:
         List of TemplateOutputFile objects that contain the compiled templates
@@ -133,7 +133,6 @@ def _compile_templates(parsed_models: dict[str, dict]) -> dict[str, list[Templat
         GeneratePluginException: An error encountered during the plugin generation process.
     """
 
-    # Define which templates we want to overwrite.
     templates_to_overwrite = ["plugin.py.jinja2", "setup.py.jinja2"]
     template_parent_directories = {"test_plugin_impl.py.jinja2": "tests"}
 

--- a/src/aac/genplug.py
+++ b/src/aac/genplug.py
@@ -146,7 +146,9 @@ def _compile_templates(parsed_models: dict[str, dict]) -> dict[str, list[Templat
         )
 
     def set_parent_directory_value(template: TemplateOutputFile):
-        template.parent_dir = template_parent_directories.get(template.template_name) or template.parent_dir
+        template.parent_dir = (
+            template_parent_directories.get(template.template_name) or template.parent_dir
+        )
 
     # ensure model is present and valid, get the plugin name
     plugin_models = util.get_models_by_type(parsed_models, "model")
@@ -224,6 +226,9 @@ def _is_user_desired_output_directory(architecture_file: str, output_dir: str) -
     while confirmation not in ["y", "n", "Y", "N"]:
         if not first:
             print(f"Unrecognized input {confirmation}:  please enter 'y' or 'n'.")
+        else:
+            first = False
+
         confirmation = input(
             f"Do you want to generate an AaC plugin in the directory {output_dir}? [y/n]"
         )
@@ -245,6 +250,7 @@ def _gather_commands(behaviors: dict) -> list[dict]:
     Returns:
         list of command-type behaviors dicts
     """
+
     def modify_command_input_output_entry(in_out_entry: dict):
         """Modifies the input and output entries of a behavior definition to reduce complexity in the templates."""
         in_out_entry["type"] = in_out_entry.get("python_type") or in_out_entry.get("type")
@@ -290,4 +296,3 @@ def _add_definitions_yaml_string(model: dict) -> dict:
 
 def _convert_to_implementation_name(original_name: str) -> str:
     return original_name.replace("-", "_")
-


### PR DESCRIPTION
As a plugin developer, I want Genplugin to generate my plugin with a proper directory structure, so that my plugin's package is compatible with the package-based functions in Pluggy and Jinja2 .

AC:
- [x] Genplugin generates `setup.py` at the same level as the plugin AaC file
- [x] Genplugin generates a plugin package directory at the same level as the plugin AaC file
- [x] The plugin package directory has the same name as the plugin, and the directory name is snake_case (python style) (plugin name 'aac-gen-protobuf' would result in a directory named 'aac_gen_protobuf')
- [x] Genplugin generates the `plugin.py` file in the plugin package directory
- [x] Genplugin generates the `plugin_impl.py` file in the plugin package directory
- [x] Genplugin generates the `__init__.py` file in the plugin package directory

Changes:
- Update `genplug.py` to generate `plugin.py`, `plugin_impl.py`, and
  `__init__.py` into a package directory instead of the top-level plugin
  directory.