### PR TITLE
136 make spec self documenting

### DIFF
--- a/src/aac/plugins/gen_plugin/gen_plugin.yaml
+++ b/src/aac/plugins/gen_plugin/gen_plugin.yaml
@@ -51,11 +51,3 @@ ext:
    enumExt:
       add:
          - command
----
-ext:
-   name: DescriptField
-   type: Field
-   dataExt:
-      add:
-        - name: description
-          type: string

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -105,6 +105,8 @@ data:
       type: string
     - name: type
       type: string
+    - name: description
+      type: string
   required:
     - name
     - type

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -179,10 +179,21 @@ data:
   fields:
     - name: name
       type: string
+      description: |
+        The name of the field.
+
+        Used to refer to the field, in certain cases.
     - name: type
       type: string
+      description: |
+        The type of the field.
+
+        Used to constrain the field's values to make it simpler to reason about.
     - name: description
       type: string
+      description: |
+        A description for the field to let users know what it's for and any
+        other useful information.
   required:
     - name
     - type

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -350,8 +350,12 @@ data:
   fields:
     - name: condition
       type: string
+      description: |
+        A condition to test whether a sequence of steps should be performed.
     - name: steps
       type: Step[]
+      description: |
+        A list of steps to perform if the condition for the branch is "true".
   required:
     - condition
     - steps

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -113,8 +113,13 @@ data:
   fields:
     - name: add
       type: Field[]
+      description: |
+        The list of fields to add to a `data' extension.
     - name: required
       type: string[]
+      description: |
+        The list of names of all the additional fields that are required for the
+        extended definition.
   required:
     - add
 ---

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -7,8 +7,9 @@ data:
     - name: import
       type: string[]
       description: |
-        A list references to dependent models whose definitions should be
-        available for use by the current model.
+        A list of references to other models composing the current model. 
+        
+        Component model definitions must be visible from the current model's scope.
     - name: enum
       type: enum
       description: |
@@ -188,7 +189,8 @@ data:
       description: |
         The type of the field.
 
-        Used to constrain the field's values to make it simpler to reason about.
+        Used to constrain the field's values to make it simpler to reason about. Must 
+        reference an existing definition by name.
     - name: description
       type: string
       description: |
@@ -264,7 +266,7 @@ data:
     - name: name
       type: string
       description: |
-        The name of the system model.
+        The name of the model.
     - name: description
       type: string
       description: |
@@ -273,7 +275,7 @@ data:
     - name: components
       type: Field[]
       description: |
-        A list of the components that are part of the system.
+        A list of models that are components of the system.
     - name: behavior
       type: Behavior[]
       description: |

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -6,16 +6,48 @@ data:
   fields:
     - name: import
       type: string[]
+      description: |
+        A list references to dependent models whose definitions should be
+        available for use by the current model.
     - name: enum
       type: enum
+      description: |
+        A definition that represents an enumerated type of value.
+
+        An example of when to use an `enum' is when you want to provide several
+        different options for a single value.
     - name: data
       type: data
+      description: |
+        A definition that represents a data value.
+
+        An example of when to use a `data' definition is when you want to define
+        some part of the system that can be an input and/or output to another
+        part of the system.
     - name: model
       type: model
+      description: |
+        A definition that represents a system and/or component model.
+
+        An example of when to use a `model' is when you want to define the
+        behavior for some component of the system.
     - name: usecase
       type: usecase
+      description: |
+        A definition that represents a usecase for the system.
+
+        An example of when to use a `usecase' is when you want to define how the
+        system might be used in a particular instance.
     - name: ext
       type: extension
+      description: |
+        A meta definition used for adding information to another definition.
+
+        An example of when to use an `ext' is when you wish to add extra
+        information to a model that isn't included in the core specification or
+        the specification of any plugins you may have installed.
+
+        You can extend any `enum' and `data' definition.
 ---
 data:
   name: enum

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -316,18 +316,34 @@ data:
   fields:
     - name: step
       type: string
+      description: |
+        The name of the step.
     - name: source
       type: string
+      description: |
+        The source for the step. This should be the name of a particpant - i.e.
+        a modeled system component.
     - name: target
       type: string
+      description: |
+        The target for the step. This should be the name of a particpant - i.e.
+        a modeled system component.
     - name: action
       type: string
+      description: |
+        A behavior reference on the target or a subordinate use case definition.
     - name: if
       type: Branch
+      description: |
+        Used to create an "alt" in a sequence diagram.
     - name: else
       type: Branch
+      description: |
+        Used to create the "lower cell" in an "alt" in a sequence diagram.
     - name: loop
       type: Branch
+      description: |
+        Used to create a loop in a sequence diagram.
 ---
 data:
   name: Branch

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -223,18 +223,37 @@ data:
   fields:
     - name: name
       type: string
+      description: |
+        The name of the behavior.
     - name: type
       type: BehaviorType
+      description: |
+        The type of behavior.
     - name: description
       type: string
+      description: |
+        An explanatory description of the behavior, including what the behavior
+        is, why it exists, etc.
     - name: tags
       type: string[]
+      description: |
+        Tags associated with the behavior. These could be used to group similar
+        behaviors into categories like "timing", "network", etc.
     - name: input
       type: Field[]
+      description: |
+        The list of all the fields that are inputs to the component when the
+        behavior is performed.
     - name: output
       type: Field[]
+      description: |
+        The list of all the fields that are outputs to the component when the
+        behavior is performed.
     - name: acceptance
       type: Scenario[]
+      description: |
+        A list of scenarios that define the acceptance criteria to signify that
+        the system is behaving as expected.
   required:
     - name
     - type

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -69,12 +69,31 @@ data:
   fields:
     - name: name
       type: string
+      description: |
+        The name of the extension.
     - name: type
       type: string
+      description: |
+        The name of the `data' or `enum' definition that this definition is
+        extending.
     - name: enumExt
       type: EnumExtension
+      description: |
+        If extending an `enum' definition, this represents a list of the items
+        to add to the `enum's `values' property.
+
+        Note: Only one of `enumExt' and `dataExt' are valid per extension.
+
+        See also, `EnumExtension'
     - name: dataExt
       type: DataExtension
+      description: |
+        If extending an `data' definition, this represents a list of the items
+        to add to the `data's `fields' property.
+
+        Note: Only one of `enumExt' and `dataExt' are valid per extension.
+
+        See also, `DataExtension'
   required:
     - name
     - type

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -279,7 +279,7 @@ data:
     - name: behavior
       type: Behavior[]
       description: |
-        A list of behaviors that the system will perform.
+        A list of behaviors that the system being modeled will perform.
   required:
     - name
 ---

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -286,12 +286,26 @@ data:
   fields:
     - name: name
       type: string
+      description: |
+        The name of the use case.
     - name: description
       type: string
+      description: |
+        An explanatory description of the use case to include what purpose the
+        use case serves, design ideas when fullfilling the use case, etc.
     - name: participants
       type: Field[]
+      description: |
+        A list of participants in the use case.
+
+        Generally, these would be users, other systems, etc. that are
+        interacting with the system during the course of the use case.
     - name: steps
       type: Step[]
+      description: |
+        A list of steps taken in the use case.
+
+        See `Step'
   required:
     - name
     - participants

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -103,6 +103,8 @@ data:
   fields:
     - name: add
       type: string[]
+      description: |
+        The list of values to add to an `enum' extension.
   required:
     - add
 ---

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -263,12 +263,21 @@ data:
   fields:
     - name: name
       type: string
+      description: |
+        The name of the system model.
     - name: description
       type: string
+      description: |
+        An explanatory description for the model including what the
+        component/system is modeleing and any other relevant information.
     - name: components
       type: Field[]
+      description: |
+        A list of the components that are part of the system.
     - name: behavior
       type: Behavior[]
+      description: |
+        A list of behaviors that the system will perform.
   required:
     - name
 ---

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -203,10 +203,17 @@ data:
   fields:
     - name: name
       type: string
+      description: |
+        The name of the data definition.
     - name: fields
       type: Field[]
+      description: |
+        A list of fields that make up the definition.
     - name: required
       type: string[]
+      description: |
+        The list of names of all the fields that are required for the
+        definition.
   required:
     - name
     - fields

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -7,22 +7,22 @@ data:
     - name: import
       type: string[]
       description: |
-        A list of references to other models composing the current model. 
-        
+        A list of references to other models composing the current model.
+
         Component model definitions must be visible from the current model's scope.
     - name: enum
       type: enum
       description: |
         A definition that represents an enumerated type of value.
 
-        An example of when to use an `enum' is when you want to provide several
+        An example of when to use an 'enum' is when you want to provide several
         different options for a single value.
     - name: data
       type: data
       description: |
         A definition that represents a data value.
 
-        An example of when to use a `data' definition is when you want to define
+        An example of when to use a 'data' definition is when you want to define
         some part of the system that can be an input and/or output to another
         part of the system.
     - name: model
@@ -30,25 +30,25 @@ data:
       description: |
         A definition that represents a system and/or component model.
 
-        An example of when to use a `model' is when you want to define the
+        An example of when to use a 'model' is when you want to define the
         behavior for some component of the system.
     - name: usecase
       type: usecase
       description: |
         A definition that represents a usecase for the system.
 
-        An example of when to use a `usecase' is when you want to define how the
+        An example of when to use a 'usecase' is when you want to define how the
         system might be used in a particular instance.
     - name: ext
       type: extension
       description: |
         A meta definition used for adding information to another definition.
 
-        An example of when to use an `ext' is when you wish to add extra
+        An example of when to use an 'ext' is when you wish to add extra
         information to a model that isn't included in the core specification or
         the specification of any plugins you may have installed.
 
-        You can extend any `enum' and `data' definition.
+        You can extend any 'enum' and 'data' definition.
 ---
 data:
   name: enum
@@ -75,26 +75,26 @@ data:
     - name: type
       type: string
       description: |
-        The name of the `data' or `enum' definition that this definition is
+        The name of the 'data' or 'enum' definition that this definition is
         extending.
     - name: enumExt
       type: EnumExtension
       description: |
-        If extending an `enum' definition, this represents a list of the items
-        to add to the `enum's `values' property.
+        If extending an 'enum' definition, this represents a list of the items
+        to add to the 'enum's 'values' property.
 
-        Note: Only one of `enumExt' and `dataExt' are valid per extension.
+        Note: Only one of 'enumExt' and 'dataExt' are valid per extension.
 
-        See also, `EnumExtension'
+        See also, 'EnumExtension'
     - name: dataExt
       type: DataExtension
       description: |
-        If extending an `data' definition, this represents a list of the items
-        to add to the `data's `fields' property.
+        If extending an 'data' definition, this represents a list of the items
+        to add to the 'data's 'fields' property.
 
-        Note: Only one of `enumExt' and `dataExt' are valid per extension.
+        Note: Only one of 'enumExt' and 'dataExt' are valid per extension.
 
-        See also, `DataExtension'
+        See also, 'DataExtension'
   required:
     - name
     - type
@@ -105,7 +105,7 @@ data:
     - name: add
       type: string[]
       description: |
-        The list of values to add to an `enum' extension.
+        The list of values to add to an 'enum' extension.
   required:
     - add
 ---
@@ -115,7 +115,7 @@ data:
     - name: add
       type: Field[]
       description: |
-        The list of fields to add to a `data' extension.
+        The list of fields to add to a 'data' extension.
     - name: required
       type: string[]
       description: |
@@ -189,7 +189,7 @@ data:
       description: |
         The type of the field.
 
-        Used to constrain the field's values to make it simpler to reason about. Must 
+        Used to constrain the field's values to make it simpler to reason about. Must
         reference an existing definition by name.
     - name: description
       type: string
@@ -307,7 +307,7 @@ data:
       description: |
         A list of steps taken in the use case.
 
-        See `Step'
+        See 'Step'
   required:
     - name
     - participants

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -128,14 +128,28 @@ data:
   fields:
     - name: scenario
       type: string
+      description: |
+        The name of the scenario.
     - name: tags
       type: string[]
+      description: |
+        Tags associated with the scenario. These could be used to group similar
+        scenarios into categories like "front-end", "back-end", etc.
     - name: given
       type: string[]
+      description: |
+        A list of preconditions that must be true in order for the scenario to
+        perform the expected action or provide the expected result.
     - name: when
       type: string[]
+      description: |
+        A list of triggers that indicate some reason for the system to act in a
+        certain way or provide some result.
     - name: then
       type: string[]
+      description: |
+        A list of postconditions that will be true once the system has completed
+        its action based on the triggers.
   required:
     - scenario
     - when

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -9,7 +9,8 @@ data:
       description: |
         A list of references to other models composing the current model.
 
-        Component model definitions must be visible from the current model's scope.
+        Component model definitions must be visible from the current model's
+        scope.
     - name: enum
       type: enum
       description: |
@@ -22,9 +23,8 @@ data:
       description: |
         A definition that represents a data value.
 
-        An example of when to use a 'data' definition is when you want to define
-        some part of the system that can be an input and/or output to another
-        part of the system.
+        A 'data' definition can generally be thought of as shorthand for 'data
+        structure'.
     - name: model
       type: model
       description: |

--- a/src/aac/spec/spec.yaml
+++ b/src/aac/spec/spec.yaml
@@ -54,8 +54,12 @@ data:
   fields:
     - name: name
       type: string
+      description: |
+        The name of the enumeration.
     - name: values
       type: string[]
+      description: |
+        A list of strings that encompass the enumeration's possible values.
   required:
     - name
     - values


### PR DESCRIPTION
Closes #136

Changes:

- Add the `description` property to the `data` definition.
- Remove the `DescriptField` extension from `gen_plugin.yaml`.
- Add descriptions for all items in the core spec.