### PR TITLE
Add PyPI Package Deployment 

### DIFF
--- a/.github/workflows/deploy-artifacts.yml
+++ b/.github/workflows/deploy-artifacts.yml
@@ -1,7 +1,7 @@
 name: Deploy AaC Artifacts
 
 on:
-  workflow_call:
+  workflow_dispatch:
     # secrets:
     #   PYPI_API_TOKEN:
     #     required: true

--- a/.github/workflows/deploy-artifacts.yml
+++ b/.github/workflows/deploy-artifacts.yml
@@ -2,11 +2,11 @@ name: Deploy AaC Artifacts
 
 on:
   workflow_dispatch:
-    # secrets:
-    #   PYPI_API_TOKEN:
-    #     required: true
 
 jobs:
+  Build_Package_and_Artifacts:
+    uses: jondavid-black/AaC/.github/workflows/build-artifacts.yml@1e3f89c23eb6583116848d81ccd5ad952f9a62b6
+
   Deploy-Artifacts:
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +27,6 @@ jobs:
 
       - name: Publish distribution to PyPI
         run: echo "This is where I'd deploy if I were setup"
-  #     if: startsWith(github.ref, 'refs/tags')
   #     uses: pypa/gh-action-pypi-publish@master
   #     with:
   #       password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy-artifacts.yml
+++ b/.github/workflows/deploy-artifacts.yml
@@ -26,7 +26,6 @@ jobs:
           path: dist/
 
       - name: Publish distribution to PyPI
-        run: echo "This is where I'd deploy if I were setup"
   #     uses: pypa/gh-action-pypi-publish@master
   #     with:
   #       password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,5 +1,4 @@
-name: Build Package and Artifacts
-
+name: Functional Tests
 on:
   workflow_call:
 

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -12,6 +12,3 @@ jobs:
   Run_Functional_Tests:
     needs: Build_Package_and_Artifacts
     uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@80bdd88b0d35b04c14d7e54d4c1de1c3f2ef0e69
-  Deploy_Artifacts:
-    needs: Run_Functional_Tests
-    uses: jondavid-black/AaC/.github/workflows/deploy-artifacts.yml@1e3f89c23eb6583116848d81ccd5ad952f9a62b6

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,6 +2,7 @@ tasks:
   - name: Setup Python Virtual Environment
     init: |
       python3.9 -m venv venv --system-site-packages
+      python3.9 -m pip install --upgrade pip
       source venv/bin/activate
       pip install -e .[all]
     command: source venv/bin/activate # Always launch a console with our virtual env

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Main branch AaC Workflow](https://github.com/jondavid-black/AaC/actions/workflows/main-branch.yml/badge.svg)](https://github.com/jondavid-black/AaC/actions/workflows/main-branch.yml)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 # Architecture-as-Code (AaC)

--- a/pyproject.toml.old
+++ b/pyproject.toml.old
@@ -7,7 +7,7 @@ always-on = true
 
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=60",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ runtime_dependencies = [
 
 development_dependencies = [
     "wheel == 0.37.0",
-    "black == 21.9b0",
+    "tomli < 2.0.0",
+    "black == 21.12b0",
     "mccabe == 0.6.1",
     "mypy-extensions == 0.4.3",
     "pycodestyle >= 2.8.0",


### PR DESCRIPTION
Closes #114 

Due to the nature of how Gtihub Actions work, I forked the AaC repo in order to try and "test" the workflow before this PR. I attempted to use the test PyPI index `https://test.pypi.org/`, but the AaC package is already there and tied to JD's account. So, I've included the reference file and pipeline to demonstrate that the pipeline works up until it hits a user permissions error, which we shouldn't see here.

The mostly-successful GHA run be found here: 
https://github.com/Coffee2Bits/AaC/actions/runs/1613374176

The forked workflow file can be found here: https://github.com/Coffee2Bits/AaC/blob/37a1de534585f0f079abbd119d13233b31d30043/.github/workflows/deploy-artifacts.yml

Changes:
* Removed the deploy artifacts from the main branch workflow
* Deploy artifacts is now a manual workflow ([Docs can be found here](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow))
* Removed the git tag check for the deployment stage -- we won't want to use this as a trigger since github has yet to implement protected tags like they have for branches. ([See feature request thread here.](https://github.community/t/feature-request-protected-tags/1742)) 
* Addressed some dependency clashes that popped up
