### PR TITLE
Add os matrix functional test

### DIFF
--- a/.github/workflows/deploy-artifacts.yml
+++ b/.github/workflows/deploy-artifacts.yml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  Build_Package_and_Artifacts:
+  Build_Artifacts:
     uses: jondavid-black/AaC/.github/workflows/build-artifacts.yml@1e3f89c23eb6583116848d81ccd5ad952f9a62b6
 
   Deploy-Artifacts:
     runs-on: ubuntu-latest
-    needs: Build_Package_and_Artifacts
+    needs: Build_Artifacts
     steps:
       - name: Download API Documentation
         uses: actions/download-artifact@v2

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -48,7 +48,7 @@ jobs:
 
       strategy:
           matrix:
-            os: [ubuntu-latest, macos-latest, windows-latest]
+            os: [ubuntu-latest, windows-latest]
 
       steps:
         - name: Checkout Repository

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -42,7 +42,7 @@ jobs:
         cp  src/aac/plugins/gen_protobuf/gen_protobuf.yaml gen_plugin_generation_test
         echo y | aac gen-plugin gen_plugin_generation_test/gen_protobuf.yaml
 
-  OS_Matrix_Tests:
+  OS_Matrix:
       needs: Package_Functional_Tests
       runs-on: ${{matrix.os}}
 

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -5,6 +5,10 @@ on:
 jobs:
   Package_Functional_Tests:
     runs-on: ubuntu-latest
+
+    outputs:
+      wheel_name: ${{ steps.wheel_artifact.outputs.wheel_name }}
+
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
@@ -20,6 +24,10 @@ jobs:
         name: aac_wheel
         path: dist/
 
+    - name: Set Wheel Artifact Name
+      id: wheel_artifact
+      run: echo "::set-output name=wheel_name::$(basename $(ls dist/*.whl))"
+
     - name: Install Wheel Distribution
       run: pip install dist/*.whl
 
@@ -28,15 +36,44 @@ jobs:
         find src -name spec.yaml -print0 | xargs -0 -n1 aac validate
         find src/aac/plugins -name *.yaml -print0 | xargs -0 -n1 aac validate
 
-    - name: Validate Example Model
-      run: |
-        aac validate model/flow/System.yaml
-
     - name: Test gen-plugin
       run: |
         mkdir gen_plugin_generation_test
         cp  src/aac/plugins/gen_protobuf/gen_protobuf.yaml gen_plugin_generation_test
         echo y | aac gen-plugin gen_plugin_generation_test/gen_protobuf.yaml
 
-    - name: Print out Core Spec
-      run: aac aac-core-spec
+  OS_Matrix_Tests:
+      needs: Package_Functional_Tests
+      runs-on: ${{matrix.os}}
+
+      strategy:
+          matrix:
+            os: [ubuntu-latest, macos-latest, windows-latest]
+
+      steps:
+        - name: Checkout Repository
+          uses: actions/checkout@v2
+
+        - name: Set up Python 3.9
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.9
+
+        - name: Download Python Wheel
+          uses: actions/download-artifact@v2
+          id: download-wheel
+          with:
+            name: aac_wheel
+            path: dist/
+
+        - name: Install Wheel Distribution
+          run: pip install ${{steps.download-wheel.outputs.download-path}}/${{needs.Package_Functional_Tests.outputs.wheel_name}}
+
+        - name: Validate Core Spec
+          run: python -m aac validate src/aac/spec/spec.yaml
+
+        - name: Print out Core Spec
+          run: python -m aac aac-core-spec
+
+        - name: Validate Example Model
+          run: python -m aac validate model/flow/System.yaml

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -11,4 +11,4 @@ jobs:
 
   Functional_Tests:
     needs: Build_Artifacts
-    uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@aeb5a269280e042a3da003782371128ef6029e6b
+    uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@ff8c3577e72078e35e758669f044601cda05fafe

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -6,9 +6,9 @@ on:
     branches: [main]
 
 jobs:
-  Build_Package_and_Artifacts:
+  Build_Artifacts:
     uses: jondavid-black/AaC/.github/workflows/build-artifacts.yml@2f31748af5e838d581bfce55111a76ee5c8d0add
 
-  Run_Functional_Tests:
-    needs: Build_Package_and_Artifacts
+  Functional_Tests:
+    needs: Build_Artifacts
     uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@80bdd88b0d35b04c14d7e54d4c1de1c3f2ef0e69

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -11,4 +11,4 @@ jobs:
 
   Functional_Tests:
     needs: Build_Artifacts
-    uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@80bdd88b0d35b04c14d7e54d4c1de1c3f2ef0e69
+    uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@aeb5a269280e042a3da003782371128ef6029e6b

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -11,4 +11,4 @@ jobs:
 
   Functional_Tests:
     needs: Build_Artifacts
-    uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@ff8c3577e72078e35e758669f044601cda05fafe
+    uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@e900b85adc127f80f53663f91bfb34d32cfe080f

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -5,9 +5,9 @@ on:
   pull_request:
 
 jobs:
-  Build_Package_and_Artifacts:
+  Build_Artifacts:
     uses: jondavid-black/AaC/.github/workflows/build-artifacts.yml@2f31748af5e838d581bfce55111a76ee5c8d0add
 
-  Run_Functional_Tests:
-    needs: Build_Package_and_Artifacts
+  Functional_Tests:
+    needs: Build_Artifacts
     uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@80bdd88b0d35b04c14d7e54d4c1de1c3f2ef0e69

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -10,4 +10,4 @@ jobs:
 
   Functional_Tests:
     needs: Build_Artifacts
-    uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@aeb5a269280e042a3da003782371128ef6029e6b
+    uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@ff8c3577e72078e35e758669f044601cda05fafe

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -10,4 +10,4 @@ jobs:
 
   Functional_Tests:
     needs: Build_Artifacts
-    uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@80bdd88b0d35b04c14d7e54d4c1de1c3f2ef0e69
+    uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@aeb5a269280e042a3da003782371128ef6029e6b

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -10,4 +10,4 @@ jobs:
 
   Functional_Tests:
     needs: Build_Artifacts
-    uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@ff8c3577e72078e35e758669f044601cda05fafe
+    uses: jondavid-black/AaC/.github/workflows/functional-tests.yml@e900b85adc127f80f53663f91bfb34d32cfe080f


### PR DESCRIPTION
Over the winter break I got a curious hair and wanted to see how difficult it would be to run our functional tests using the OS matrix feature in Github Actions. Well, it turns out it worked! So, I've brought the changes over here. 

* Added functional tests for windows and macosx environments.

I had to replace a lot of the shell-based steps since Windows doesn't have standard shell terminals.

Only downside I see is that the extra testing will eat into our monthly "allowance" of Github Actions compute time.