### PR TITLE
183 Version Number Command

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -8,13 +8,13 @@ on:
 jobs:
   build_python_artifacts:
     name: Build Python Artifacts
-    uses: jondavid-black/AaC/.github/workflows/python-build-artifacts.yml@6cd53c89ddf306c7050a6dab0b29fd40f682f564
+    uses: jondavid-black/AaC/.github/workflows/python-build-artifacts.yml@59b078023302a2244a8460676ddf93c3b824743f
 
   build_vscode_artifacts:
     name: Build VSCode Extension Artifacts
-    uses: jondavid-black/AaC/.github/workflows/vscode-build-artifacts.yml@6cd53c89ddf306c7050a6dab0b29fd40f682f564
+    uses: jondavid-black/AaC/.github/workflows/vscode-build-artifacts.yml@59b078023302a2244a8460676ddf93c3b824743f
 
   python_functional_tests:
     name: Python Functional Tests
     needs: build_python_artifacts
-    uses: jondavid-black/AaC/.github/workflows/python-functional-tests.yml@6cd53c89ddf306c7050a6dab0b29fd40f682f564
+    uses: jondavid-black/AaC/.github/workflows/python-functional-tests.yml@59b078023302a2244a8460676ddf93c3b824743f

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,13 +7,13 @@ on:
 jobs:
   build_python_artifacts:
     name: Build Python Artifacts
-    uses: jondavid-black/AaC/.github/workflows/python-build-artifacts.yml@6cd53c89ddf306c7050a6dab0b29fd40f682f564
+    uses: jondavid-black/AaC/.github/workflows/python-build-artifacts.yml@59b078023302a2244a8460676ddf93c3b824743f
 
   build_vscode_artifacts:
     name: Build VSCode Extension Artifacts
-    uses: jondavid-black/AaC/.github/workflows/vscode-build-artifacts.yml@6cd53c89ddf306c7050a6dab0b29fd40f682f564
+    uses: jondavid-black/AaC/.github/workflows/vscode-build-artifacts.yml@59b078023302a2244a8460676ddf93c3b824743f
 
   python_functional_tests:
     name: Python Functional Tests
     needs: build_python_artifacts
-    uses: jondavid-black/AaC/.github/workflows/python-functional-tests.yml@6cd53c89ddf306c7050a6dab0b29fd40f682f564
+    uses: jondavid-black/AaC/.github/workflows/python-functional-tests.yml@59b078023302a2244a8460676ddf93c3b824743f

--- a/.github/workflows/python-functional-tests.yml
+++ b/.github/workflows/python-functional-tests.yml
@@ -76,6 +76,9 @@ jobs:
         - name: Install Wheel Distribution
           run: pip install ${{steps.download-wheel.outputs.download-path}}/${{needs.python_functional_tests.outputs.wheel_name}}
 
+        - name: Get Package Version
+          run: python -m aac version
+
         - name: Validate Core Spec
           run: python -m aac validate src/aac/spec/spec.yaml
 

--- a/docs/docs/user_guide/index.md
+++ b/docs/docs/user_guide/index.md
@@ -22,6 +22,12 @@ Usage information is available from the command line interface:
 ```bash
 aac --help
 ```
+
+Installed `aac` executable version information is available via `version`:
+```bash
+aac version
+```
+
 The core functionallity of AaC provides commands to:
 - validate:  Ensures your model is correctly defined.
 - json:  Convert your model from yaml to json.
@@ -43,11 +49,11 @@ aac --help
 # Using AaC to Model Your System
 
 To use AaC you first define a model of your system in yaml.  Refer to the documentation for more details.
-A simple model for an EchoService is provided here for reference.  Cut and paste the below model into a 
-file called EchoService.yaml.  
+A simple model for an EchoService is provided here for reference.  Cut and paste the below model into a
+file called EchoService.yaml.
 *Note: This is using a little yaml trick to concatenate the content of two yaml files into a single file.*
 ```yaml
-data: 
+data:
   name: Message
   fields:
   - name: body
@@ -91,15 +97,15 @@ The AaC core root types are:
 - usecase: Allows you to model the sequence of interactions between your models.
 - ext: Allows you to easily extend the AaC model itself and tailor things to your needs.
 
-Although you can use the yaml trick above when modelling your system, it would be better to keep things more 
+Although you can use the yaml trick above when modelling your system, it would be better to keep things more
 structured and organized.  To help with this AaC allows you to define each item you model in a separate file and
-then import it as needed.  To do this just put an **import** at the root of your model file.  
+then import it as needed.  To do this just put an **import** at the root of your model file.
 
 Here's an example of the EchoService broken into two files:
 - Message.yaml
 
     ```yaml
-    data: 
+    data:
     name: Message
     fields:
     - name: body

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,6 @@
 import logging
 from setuptools import find_packages, setup
+from src.aac import VERSION
 
 README_FILE_PATH = "../README.md"
 
@@ -64,7 +65,7 @@ test_dependencies = [
 
 setup(
     name="aac",
-    version="0.0.4",
+    version=VERSION,
     description=(
         "A distinctly different take on Model-Based System Engineering (MBSE) that allows a system modeller to define a system in simple yaml. "
     ),

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,6 @@
 import logging
 from setuptools import find_packages, setup
-from src.aac import VERSION
+from src.aac import __version__
 
 README_FILE_PATH = "../README.md"
 
@@ -65,7 +65,7 @@ test_dependencies = [
 
 setup(
     name="aac",
-    version=VERSION,
+    version=__version__,
     description=(
         "A distinctly different take on Model-Based System Engineering (MBSE) that allows a system modeller to define a system in simple yaml. "
     ),

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -1,1 +1,2 @@
 """The Architecture-as-Code tool."""
+__version__ = "0.0.4"

--- a/python/src/aac/cli.py
+++ b/python/src/aac/cli.py
@@ -7,7 +7,7 @@ from typing import Callable
 
 from pluggy import PluginManager
 
-from aac import parser, plugins
+from aac import parser, plugins, __version__
 from aac.AacCommand import AacCommand, AacCommandArgument
 from aac.plugins.plugin_execution import (
     PluginExecutionResult,
@@ -47,6 +47,21 @@ def run_cli():
                 sys.exit(result.status_code.value)
 
 
+VERSION_COMMAND_NAME = "version"
+VALIDATE_COMMAND_NAME = "validate"
+CORE_SPEC_COMMAND_NAME = "aac-core-spec"
+
+
+def _version_cmd() -> PluginExecutionResult:
+    """Run the built-in verison command."""
+
+    def get_version() -> str:
+        return __version__
+
+    with plugin_result(VERSION_COMMAND_NAME, get_version) as result:
+        return result
+
+
 def _validate_cmd(model_file: str) -> PluginExecutionResult:
     """Run the built-in validate command."""
 
@@ -54,13 +69,13 @@ def _validate_cmd(model_file: str) -> PluginExecutionResult:
         with validation(parser.parse_file, model_file):
             return f"{model_file} is valid"
 
-    with plugin_result("validate", validate_model) as result:
+    with plugin_result(VALIDATE_COMMAND_NAME, validate_model) as result:
         return result
 
 
 def _core_spec_cmd() -> PluginExecutionResult:
     """Run the built-in aac-core-spec command."""
-    with plugin_result("aac-core-spec", get_aac_spec_as_yaml) as result:
+    with plugin_result(CORE_SPEC_COMMAND_NAME, get_aac_spec_as_yaml) as result:
         return result
 
 
@@ -72,20 +87,19 @@ def _setup_arg_parser(
 
     # Built-in commands
     aac_commands = [
-        # Temporarily disabled.
-        # AacCommand(
-        #     "ui",
-        #     "Run the AaC Graphical User Interface",
-        #     ui.run_ui,
-        # ),
         AacCommand(
-            "validate",
+            VALIDATE_COMMAND_NAME,
             "Ensures the AaC yaml is valid per the AaC core spec",
             _validate_cmd,
             [AacCommandArgument("model_file", "The path to the AaC model yaml file to validate")],
         ),
         AacCommand(
-            "aac-core-spec",
+            VERSION_COMMAND_NAME,
+            "Outputs Architecture-as-Code Python package version",
+            _version_cmd,
+        ),
+        AacCommand(
+            CORE_SPEC_COMMAND_NAME,
             "Prints the AaC model describing core AaC data types and enumerations",
             _core_spec_cmd,
         ),

--- a/python/tests/test_version.py
+++ b/python/tests/test_version.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+
+from aac import __version__
+from aac.cli import _version_cmd
+from aac.plugins.plugin_execution import PluginExecutionStatusCode
+
+
+class TestVersion(TestCase):
+
+    def test_version(self):
+        result = _version_cmd()
+        self.assertEqual(result.status_code, PluginExecutionStatusCode.SUCCESS)
+        self.assertIn(__version__, "\n".join(result.messages))


### PR DESCRIPTION
Closes #183 
* Moved the AaC version number into the package, it's accessible via `aac.__version__`
* Updated setup.py to use the aac package version
* Added functional and unit tests to demonstrate full coverage of the new command
* Update documentation to reference the new version command