### PR TITLE
added workflow to export issues to markdown

### DIFF
--- a/.github/workflows/issues2md.yml
+++ b/.github/workflows/issues2md.yml
@@ -3,9 +3,7 @@
 # See https://github.com/mattduck/gh2md/issues/11.
 name: Issues2Markdown
 on:
-  schedule:
-    # every day
-    - cron: "0 0 * * *"
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/issues2md.yml
+++ b/.github/workflows/issues2md.yml
@@ -1,0 +1,38 @@
+# Action to backup issues using gh2md, contributed by
+# https://github.com/0ut0fcontrol.
+# See https://github.com/mattduck/gh2md/issues/11.
+name: Issues2Markdown
+on:
+  schedule:
+    # every day
+    - cron: "0 0 * * *"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      with:
+        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+    - name: Backup github issues to a markdown file.
+      run: |
+        pip3 install --user --upgrade setuptools
+        pip3 install --user gh2md
+        $HOME/.local/bin/gh2md $GITHUB_REPOSITORY issues.md --idempotent
+        git add issues.md
+      env:
+        GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Commit files
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git diff --quiet && git diff --staged --quiet || git commit -am "Backup all issues into issues.md"
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/issues2md.yml
+++ b/.github/workflows/issues2md.yml
@@ -22,17 +22,8 @@ jobs:
         git add issues.md
       env:
         GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Commit files
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git diff --quiet && git diff --staged --quiet || git commit -am "Backup all issues into issues.md"
-    - name: Extract branch name
-      shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
-    - name: Push changes
-      uses: ad-m/github-push-action@master
+    - name: Archive issues export
+      uses: actions/upload-artifact@v2
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{ steps.extract_branch.outputs.branch }}
+        name: issues export
+        path: issues.md

--- a/.github/workflows/issues2md.yml
+++ b/.github/workflows/issues2md.yml
@@ -1,27 +1,21 @@
-# Action to backup issues using gh2md, contributed by
-# https://github.com/0ut0fcontrol.
-# See https://github.com/mattduck/gh2md/issues/11.
-name: Issues2Markdown
+name: Export Issues to Markdown
 on:
   workflow_dispatch:
+
 jobs:
   build:
+    name: Export Issues to Markdown
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-      with:
-        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
-        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-    - name: Backup github issues to a markdown file.
+    - name: Backup Github Issues to Markdown
       run: |
         pip3 install --user --upgrade setuptools
         pip3 install --user gh2md
         $HOME/.local/bin/gh2md $GITHUB_REPOSITORY issues.md --idempotent
-        git add issues.md
       env:
         GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Archive issues export
+    - name: Archive Issues Report
       uses: actions/upload-artifact@v2
       with:
-        name: issues export
+        name: issues_export
         path: issues.md


### PR DESCRIPTION
This is an attempt to capture issues in a form that will help us work through some bureaucracy.  I took this from the gh2md repo where it seems to work fine, but I have no ability to test it.  Seems like a small risk because if the GH action fails we can choose to try and fix it or just delete the workflow it if is too painful.