### PR TITLE
Update gen-json to create output directories if they do not exist

### DIFF
--- a/python/src/aac/plugins/gen_json/gen_json_impl.py
+++ b/python/src/aac/plugins/gen_json/gen_json_impl.py
@@ -15,7 +15,7 @@ plugin_name = "gen-json"
 
 
 def print_json(architecture_files: list[str], output_directory: str = None) -> PluginExecutionResult:
-    """Prints the parsed_models from the parsed architecture_files values in JSON format.
+    """Print the parsed_models from the parsed architecture_files values in JSON format.
 
     Arguments:
         architecture_files (list[str]): filepath to the architecture file to convert to JSON.
@@ -36,17 +36,15 @@ def print_json(architecture_files: list[str], output_directory: str = None) -> P
                 output_file_path = os.path.join(output_directory, f"{file_name}.json")
                 with open(output_file_path, "w") as out_file:
                     out_file.write(formatted_json)
+                    return f"Wrote JSON to {output_file_path}."
 
-                return f"Wrote JSON to {output_file_path}."
-
-            else:
-                return f"File: {architecture_file_path}\n{formatted_json}\n"
+            return f"File: {architecture_file_path}\n{formatted_json}\n"
 
     status = PluginExecutionStatusCode.SUCCESS
     messages = []
     for arch_file in architecture_files:
         with plugin_result(plugin_name, to_json, arch_file, output_directory) as result:
-            messages = messages + result.messages
+            messages += result.messages
             if not result.is_success():
                 status = result.status_code
 

--- a/python/src/aac/plugins/gen_json/gen_json_impl.py
+++ b/python/src/aac/plugins/gen_json/gen_json_impl.py
@@ -30,8 +30,10 @@ def print_json(architecture_files: list[str], output_directory: str = None) -> P
             formatted_json = json.dumps(result.model, indent=2)
 
             if output_directory:
-                output_file_path = os.path.join(output_directory, f"{file_name}.json")
+                if not os.path.exists(output_directory):
+                    os.makedirs(output_directory)
 
+                output_file_path = os.path.join(output_directory, f"{file_name}.json")
                 with open(output_file_path, "w") as out_file:
                     out_file.write(formatted_json)
 

--- a/python/tests/plugins/test_gen_json.py
+++ b/python/tests/plugins/test_gen_json.py
@@ -16,6 +16,14 @@ class TestGenJson(TestCase):
             self.assertEqual(result.status_code, PluginExecutionStatusCode.SUCCESS)
             self.assertIn("Wrote JSON to", "\n".join(result.messages))
 
+    def test_gen_json_with_output_directory_that_does_not_exist(self):
+        with temporary_test_file(TEST_ARCH_YAML_STRING) as temp_arch_file:
+            temp_dir = os.path.join(os.path.dirname(temp_arch_file.name), "does", "not", "exist")
+            self.assertFalse(os.path.exists(temp_dir))
+            result = print_json([temp_arch_file.name], temp_dir)
+            self.assertEqual(result.status_code, PluginExecutionStatusCode.SUCCESS)
+            self.assertTrue(os.path.exists(temp_dir))
+
     def test_gen_json_output_to_cli(self):
         with temporary_test_file(TEST_ARCH_YAML_STRING) as temp_arch_file:
             result = print_json([temp_arch_file.name])

--- a/python/tests/plugins/test_gen_json.py
+++ b/python/tests/plugins/test_gen_json.py
@@ -1,40 +1,38 @@
+import os
+
 from unittest import TestCase
 from tempfile import TemporaryDirectory, NamedTemporaryFile
 
 from aac.plugins.gen_json.gen_json_impl import print_json
 from aac.plugins.plugin_execution import PluginExecutionStatusCode
 
+from tests.helpers.io import temporary_test_file
+
 
 class TestGenJson(TestCase):
 
     def test_print_json_with_output_directory(self):
-
-        with TemporaryDirectory() as temp_dir, NamedTemporaryFile("w") as temp_arch_file:
-            temp_arch_file.write(TEST_ARCH_YAML_STRING)
-            temp_arch_file.seek(0)
-
+        with temporary_test_file(TEST_ARCH_YAML_STRING) as temp_arch_file:
+            temp_dir = os.path.dirname(temp_arch_file.name)
             result = print_json([temp_arch_file.name], temp_dir)
             self.assertEqual(result.status_code, PluginExecutionStatusCode.SUCCESS)
             self.assertIn("Wrote JSON to", "\n".join(result.messages))
 
     def test_gen_json_output_to_cli(self):
-
-        with TemporaryDirectory(), NamedTemporaryFile("w") as temp_arch_file:
-            temp_arch_file.write(TEST_ARCH_YAML_STRING)
-            temp_arch_file.seek(0)
-
+        with temporary_test_file(TEST_ARCH_YAML_STRING) as temp_arch_file:
             result = print_json([temp_arch_file.name])
             self.assertEqual(result.status_code, PluginExecutionStatusCode.SUCCESS)
             self.assertIn('"name": "Test_model"', "\n".join(result.messages))
 
     def test_gen_json_with_invalid_arch_file(self):
-
-        with TemporaryDirectory(), NamedTemporaryFile("w") as temp_arch_file:
-            temp_arch_file.write(BAD_YAML_STRING)
-            temp_arch_file.seek(0)
-
+        with temporary_test_file(BAD_YAML_STRING) as temp_arch_file:
             result = print_json([temp_arch_file.name])
             self.assertEqual(result.status_code, PluginExecutionStatusCode.VALIDATION_FAILURE)
+
+    def test_gen_json_with_unparsable_file(self):
+        with temporary_test_file("model: ][") as temp_arch_file:
+            result = print_json([temp_arch_file.name])
+            self.assertEqual(result.status_code, PluginExecutionStatusCode.PARSER_FAILURE)
 
 
 TEST_ARCH_YAML_STRING = """
@@ -48,7 +46,6 @@ model:
       input:
         - name: architecture_file
           type: string
-
 """
 
 BAD_YAML_STRING = """
@@ -62,5 +59,4 @@ model:
       input:
         - name: architecture
           type: string
-
 """

--- a/python/tests/plugins/test_gen_json.py
+++ b/python/tests/plugins/test_gen_json.py
@@ -1,7 +1,6 @@
 import os
 
 from unittest import TestCase
-from tempfile import TemporaryDirectory, NamedTemporaryFile
 
 from aac.plugins.gen_json.gen_json_impl import print_json
 from aac.plugins.plugin_execution import PluginExecutionStatusCode
@@ -10,7 +9,6 @@ from tests.helpers.io import temporary_test_file
 
 
 class TestGenJson(TestCase):
-
     def test_print_json_with_output_directory(self):
         with temporary_test_file(TEST_ARCH_YAML_STRING) as temp_arch_file:
             temp_dir = os.path.dirname(temp_arch_file.name)


### PR DESCRIPTION
Closes #204 

Changes:
- In the `gen-json` plugin, create output non-existent directories before trying to write the output JSON.