### PR TITLE
Use the configured AaC executable in the extension

### DIFF
--- a/vscode_extension/src/aacExecutableWrapper.ts
+++ b/vscode_extension/src/aacExecutableWrapper.ts
@@ -108,9 +108,8 @@ async function execAacShellCommand(command: string, commandArgs: CommandArgument
         .map(argument => argument.optional ? `${argument.name} ${argument.userResponse}` : argument.userResponse);
 
     const aac = getConfigurationItem("aacPath") || "aac";
-    const cmd = [aac, command, ...commandArgsArray].join(" ");
     try {
-        const { stdout, stderr } = await execShell(cmd, {});
+        const { stdout, stderr } = await execShell([aac, command, ...commandArgsArray].join(" "), {});
         return stderr.length > 0 ? stderr : stdout;
     } catch (error: any) {
         let errorMessage = error.stderr || error.stdout || "urecognized error";

--- a/vscode_extension/src/aacExecutableWrapper.ts
+++ b/vscode_extension/src/aacExecutableWrapper.ts
@@ -1,4 +1,4 @@
-import { execShell } from "./helpers";
+import { execShell, getConfigurationItem } from "./helpers";
 import { getOutputChannel } from "./outputChannel";
 import { window, QuickPickOptions, InputBoxOptions, OpenDialogOptions, Uri } from 'vscode';
 
@@ -107,8 +107,10 @@ async function execAacShellCommand(command: string, commandArgs: CommandArgument
         .filter(argument => argument.userResponse)
         .map(argument => argument.optional ? `${argument.name} ${argument.userResponse}` : argument.userResponse);
 
+    const aac = getConfigurationItem("aacPath") || "aac";
+    const cmd = [aac, command, ...commandArgsArray].join(" ");
     try {
-        const { stdout, stderr } = await execShell(["aac", command, ...commandArgsArray].join(" "), {});
+        const { stdout, stderr } = await execShell(cmd, {});
         return stderr.length > 0 ? stderr : stdout;
     } catch (error: any) {
         let errorMessage = error.stderr || error.stdout || "urecognized error";


### PR DESCRIPTION
Changes:
- If the user has configured the `aacPath`, then use that value; otherwise, default to searching the path for a globally available `aac` executable.