### PR TITLE
Update the VSCode extension to leverage the help-dump command

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -6,7 +6,6 @@ __version__ = "0.1.0"
 
 logging.basicConfig(
     format="%(asctime)s::%(module)s::%(filename)s::L%(lineno)d::%(levelname)s::%(message)s",
-    filename="aac.log",
     encoding="utf-8",
     level=logging.DEBUG,
     datefmt="%m/%d/%Y %H:%M:%S",

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -1,11 +1,13 @@
 """The Architecture-as-Code tool."""
 
 import logging
+import os
 
 __version__ = "0.1.0"
 
 logging.basicConfig(
     format="%(asctime)s::%(module)s::%(filename)s::L%(lineno)d::%(levelname)s::%(message)s",
+    filename=os.path.join(os.path.dirname(__file__), "aac.log"),
     encoding="utf-8",
     level=logging.DEBUG,
     datefmt="%m/%d/%Y %H:%M:%S",

--- a/python/src/aac/plugins/start_lsp/__init__.py
+++ b/python/src/aac/plugins/start_lsp/__init__.py
@@ -20,11 +20,11 @@ def get_commands() -> list[AacCommand]:
     start_lsp_tcp_arguments = [
         AacCommandArgument(
             "--host",
-            "The host address to bind the TCP server to. Defaults to \"127.0.0.1\".",
+            "The host address to bind the TCP server to. Defaults to 127.0.0.1.",
         ),
         AacCommandArgument(
             "--port",
-            "The host port to bing the TCP server to. Defaults to \"5007\"."
+            "The host port to bing the TCP server to. Defaults to 5007."
         ),
     ]
 

--- a/vscode_extension/src/aacExecutableWrapper.ts
+++ b/vscode_extension/src/aacExecutableWrapper.ts
@@ -5,10 +5,17 @@ import { window, QuickPickOptions, InputBoxOptions, OpenDialogOptions, Uri } fro
 const outputChannel = getOutputChannel();
 
 interface CommandArgument {
-    name?: string;
-    description?: string;
+    name: string;
+    description: string;
+    dataType?: string;
     userResponse?: string;
     optional?: boolean;
+}
+
+interface Command {
+    name: string;
+    description: string;
+    arguments: CommandArgument[];
 }
 
 /**
@@ -16,27 +23,27 @@ interface CommandArgument {
  * information and arguments.
  */
 export async function executeAacCommand(): Promise<void> {
-    let availableCommands: string[] = await getAacCommandNames();
+    const helpDumpOutput = await execAacShellCommand("help-dump");
+    const helpJson: string = helpDumpOutput.split("\n").filter(it => it !== "")[1];
+    const availableCommands: Command[] = JSON.parse(helpJson);
 
     const quickPickOptions: QuickPickOptions = {
         canPickMany: false,
     };
 
-    window.showQuickPick(availableCommands, quickPickOptions).then(commandName => {
-        if (commandName) {
-            executeCommandWithArguments(commandName).then((output: string) => {
-                outputChannel.appendLine(output);
-                outputChannel.show();
-             });
-        }
-    });
+    window.showQuickPick(availableCommands.map(it => it.name), quickPickOptions)
+        .then(commandName => {
+            executeCommandWithArguments(availableCommands.filter(it => it.name === commandName)[0])
+                .then((output: string) => {
+                    outputChannel.appendLine(output);
+                    outputChannel.show();
+                });
+        });
 }
 
-export async function executeCommandWithArguments(commandName: string): Promise<string> {
-    return await getAacCommandArgs(commandName).then(async (commandArguments) => {
-        await getCommandArgUserInput(commandArguments);
-        return await execAacShellCommand(commandName, commandArguments);
-    });
+export async function executeCommandWithArguments(command: Command): Promise<string> {
+    await getCommandArgUserInput(command.arguments);
+    return await execAacShellCommand(command.name, command.arguments);
 }
 
 /**
@@ -44,7 +51,6 @@ export async function executeCommandWithArguments(commandName: string): Promise<
  * @returns string of the version number or null if not installed.
  */
 export async function getAaCVersion(): Promise<string | null> {
-
     let aacVersionOutput: string = "";
     try {
         aacVersionOutput = await execAacShellCommand("version");
@@ -64,7 +70,7 @@ async function getCommandArgUserInput(commandArguments: CommandArgument[]) {
 
     for (let index = 0; index < argumentsWithoutUserResponse.length; ++index) {
         let argumentToPromptUserFor = argumentsWithoutUserResponse[index];
-        if (argumentToPromptUserFor?.description?.toLowerCase().includes("path")) {
+        if (argumentToPromptUserFor.description?.toLowerCase().includes("path")) {
             const dialogBoxOptions: OpenDialogOptions = {
                 title: argumentToPromptUserFor.name,
                 canSelectMany: false
@@ -81,19 +87,6 @@ async function getCommandArgUserInput(commandArguments: CommandArgument[]) {
             argumentToPromptUserFor.userResponse = await window.showInputBox(inputBoxOptions);
         }
     }
-}
-
-async function getAacCommandNames(): Promise<string[]> {
-    const aacHelpOutput = await execAacShellCommand("-h");
-    return parseTaskNamesFromHelpCommand(aacHelpOutput);
-}
-
-/**
- * @returns list of Command arguments
- */
-async function getAacCommandArgs(aacCommandName: string): Promise<CommandArgument[]> {
-    const aacHelpOutput = await execAacShellCommand(`${aacCommandName} -h`);
-    return parseTaskArgsFromHelpCommand(aacHelpOutput);
 }
 
 /**
@@ -118,96 +111,4 @@ async function execAacShellCommand(command: string, commandArgs: CommandArgument
         outputChannel.show(true);
         throw error;
     }
-}
-
-/**
- * Parses command names from the AaC help message.
- * @param aacHelpOutput - the output to parse
- * @returns array of available command names
- */
-function parseTaskNamesFromHelpCommand(aacHelpOutput: string): string[] {
-
-    const regExp = /\{(?<commandNames>.*?)\}/;
-    const commandNamesMatch = regExp.exec(aacHelpOutput);
-
-    let commandNames: string[] = [];
-    if (commandNamesMatch?.groups?.commandNames) {
-        commandNames = commandNamesMatch.groups.commandNames.split(",");
-    }
-
-    return commandNames;
-}
-
-/**
- * Parses argument names and descriptions from command help output
- * @param aacHelpOutput - the output to parse
- * @returns array of CommandArgument objects
- */
-function parseTaskArgsFromHelpCommand(commandHelpOutput: string): CommandArgument[] {
-    const argumentSectionHeader = (name: string) => `${name} arguments:`;
-    const requiredArgsHeader = argumentSectionHeader("positional");
-    const optionalArgsHeader = argumentSectionHeader("optional");
-
-    const requiredArgsPos = commandHelpOutput.search(requiredArgsHeader) + requiredArgsHeader.length;
-    const optionalArgsPos = commandHelpOutput.search(optionalArgsHeader) + optionalArgsHeader.length;
-
-    const requiredArgsString = commandHelpOutput.substring(requiredArgsPos, optionalArgsPos);
-    const requiredArgs = getArguments(requiredArgsString);
-
-    const optionalArgsString = commandHelpOutput.substring(optionalArgsPos);
-    const optionalArgs = getArguments(optionalArgsString);
-    optionalArgs.forEach(arg => {
-        arg.name = !arg.name?.includes("--help") ? arg.name?.split(" ")[0] : arg.name;
-        arg.optional = true;
-    });
-
-    return requiredArgs.concat(optionalArgs);
-}
-
-/**
- * Parses the provided section of the help message and extracts command arguments and names.
- *
- * @param argsString - A string containing all the required or optional arguments.
- * @returns A list of required and optional {@link CommandArgument}s.
- */
-function getArguments(argsString: string) {
-    const args: CommandArgument[] = [];
-
-    let name = "";
-    let description = "";
-
-    function addArgument() {
-        if (name && description) {
-            args.push({
-                name: name.trim(),
-                description: description.trim(),
-            });
-
-            name = "";
-            description = "";
-        }
-    }
-
-    argsString
-        .split("\n")
-        .filter(it => it.length > 0)
-        .forEach((it, _, __) => {
-            if (!it.startsWith(" ", 2)) {
-                addArgument();
-
-                const str = it.substring(2);
-                const startDescriptionPos = str.search("  ");
-
-                name = startDescriptionPos >= 0
-                    ? str.substring(0, startDescriptionPos + 1)
-                    : str.trim();
-                description = startDescriptionPos >= 0
-                    ? str.substring(startDescriptionPos + 1)
-                    : "";
-            } else {
-                description += " " + it.trim();
-            }
-        });
-    addArgument();
-    return args;
 }

--- a/vscode_extension/src/test/suite/aacExecutableWrapper.test.ts
+++ b/vscode_extension/src/test/suite/aacExecutableWrapper.test.ts
@@ -4,14 +4,20 @@ import * as aacWrapper from "../../aacExecutableWrapper";
 import * as helpers from "../../helpers";
 
 suite("AaC Executable Wrapper Test Suite", () => {
-    test("we can get version of aac tool", async () => {
+    test("it should get the version of the aac tool", async () => {
         await aacWrapper.getAaCVersion()
             .then(value => assert.strictEqual(value, helpers.getConfigurationItem("version")))
             .catch(reason => assert.fail(reason));
     });
 
-    test("we can execute a command with no arguments", async () => {
-        await aacWrapper.executeCommandWithArguments("version")
+    test("it should execute a command with no arguments", async () => {
+        const versionCommand = {
+            name: "version",
+            description: "",
+            arguments: [],
+        };
+
+        await aacWrapper.executeCommandWithArguments(versionCommand)
             .then((output: string) => assert.ok(output.includes(helpers.getConfigurationItem("version"))))
             .catch(reason => assert.fail(reason));
     });


### PR DESCRIPTION
Closes #289

Changes:
- Get the AaC commands, arguments, and descriptions from the output of the `help-dump` command.
- Specify an absolute path for the log filename.