### PR TITLE
Addressed a small error case in subcomponent validator

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 logging.basicConfig(
     format="%(asctime)s::%(module)s::%(filename)s::L%(lineno)d::%(levelname)s::%(message)s",

--- a/python/src/aac/lang/language_context.py
+++ b/python/src/aac/lang/language_context.py
@@ -7,7 +7,7 @@ import logging
 
 from aac.lang.definitions.definition import Definition
 from aac.lang.definitions.search import search_definition
-from aac.lang.definitions.type import is_array_type, remove_list_type_indicator
+from aac.lang.definitions.type import remove_list_type_indicator
 from aac.lang.definition_helpers import get_definitions_by_root_key
 
 

--- a/python/src/aac/lang/language_context.py
+++ b/python/src/aac/lang/language_context.py
@@ -270,13 +270,15 @@ class LanguageContext:
         Returns:
             The definition corresponding to the name, or None if not found.
         """
-        if is_array_type(definition_name):
+        definition_to_return = None
+        if definition_name:
             definition_name = remove_list_type_indicator(definition_name)
+            definition_to_return = self.definitions_name_dictionary.get(definition_name)
 
-        definition_to_return = self.definitions_name_dictionary.get(definition_name)
-
-        if not definition_to_return:
-            logging.info(f"Failed to find the definition named '{definition_name}' in the context.")
+            if not definition_to_return:
+                logging.info(f"Failed to find the definition named '{definition_name}' in the context.")
+        else:
+            logging.error(f"No definition name was provided to {self.get_definition_by_name.__name__}")
 
         return definition_to_return
 

--- a/python/src/aac/plugins/validators/subcomponent_type/_subcomponent_type.py
+++ b/python/src/aac/plugins/validators/subcomponent_type/_subcomponent_type.py
@@ -25,17 +25,27 @@ def validate_subcomponent_types(definition_under_test: Definition, target_schema
 
         for component in subcomponents:
             component_type = component.get("type")
-            definition = language_context.get_definition_by_name(component_type)
 
-            expected_type = "model"
-            actual_type = definition and definition.get_root_key()
-            if definition and actual_type != expected_type:
-                incorrect_subcomponent_type = (
-                    f"Expected '{expected_type}' as the subcomponent type but found '{component_type}' with type "
-                    f"'{actual_type}' in: {dict_to_validate}"
+            if component_type:
+                definition = language_context.get_definition_by_name(component_type)
+
+                expected_type = "model"
+                actual_type = definition and definition.get_root_key()
+                if definition and actual_type != expected_type:
+                    incorrect_subcomponent_type = (
+                        f"Expected '{expected_type}' as the subcomponent type but found '{component_type}' with type "
+                        f"'{actual_type}' in: {dict_to_validate}"
+                    )
+                    error_messages.append(incorrect_subcomponent_type)
+                    logging.debug(incorrect_subcomponent_type)
+            else:
+                component_name = component.get("name")
+                component_missing_type = (
+                    f"Expected component '{component_name}' to have the field 'type', but was not present. Bad component:"
+                    f"{component}"
                 )
-                error_messages.append(incorrect_subcomponent_type)
-                logging.debug(incorrect_subcomponent_type)
+                error_messages.append(component_missing_type)
+                logging.debug(component_missing_type)
 
     dicts_to_test = get_substructures_by_type(definition_under_test, target_schema_definition, language_context)
     list(map(validate_model_subcomponents, dicts_to_test))

--- a/python/tests/plugins/test_gen_plant_uml.py
+++ b/python/tests/plugins/test_gen_plant_uml.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 from typing import Callable
 from unittest import TestCase
 
+from aac.lang.active_context_lifecycle_manager import get_active_context
 from aac.plugins.gen_plant_uml.gen_plant_uml_impl import (
     COMPONENT_STRING,
     OBJECT_STRING,
@@ -23,6 +24,9 @@ from tests.helpers.plugins import check_generated_file_contents, YAML_FILE_EXTEN
 
 
 class TestGenPlantUml(TestCase):
+    def setUp(self):
+        get_active_context(reload_context=True)
+
     def test_formatted_definition_name(self):
         self.assertEqual(_get_formatted_definition_name(""), "")
         self.assertEqual(_get_formatted_definition_name("name"), "name")

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -35,9 +35,10 @@
                     "enum": [
                         "0.0.5",
                         "0.1.0",
-                        "0.1.1"
+                        "0.1.1",
+                        "0.1.2"
                     ],
-                    "default": "0.1.1",
+                    "default": "0.1.2",
                     "description": "The version of the installed AaC tool."
                 },
                 "aac.aacPath": {

--- a/vscode_extension/src/test/suite/aacExecutableWrapper.test.ts
+++ b/vscode_extension/src/test/suite/aacExecutableWrapper.test.ts
@@ -1,7 +1,6 @@
 import * as assert from "assert";
 
 import * as aacWrapper from "../../aacExecutableWrapper";
-import * as helpers from "../../helpers";
 import * as configuration from "../../configuration";
 
 suite("AaC Executable Wrapper Test Suite", () => {


### PR DESCRIPTION
Found an issue where models without the field 'type' defined would cause the subcomponent validator to exception-out and didn't provide helpful feed back on the issue, since the required fields validator plugin wasn't allowed to execute/return the error about the missing field.

This is a symptom of a larger issue that I have documented in #341.