### PR TITLE
bumped all stylelint dependencies to latest

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,12 +6,12 @@
   "license": "MIT",
   "bugs": "https://github.com/pmarsceill/just-the-docs/issues",
   "devDependencies": {
-    "stylelint": "^13.7.2",
+    "stylelint": "^14.9.1",
     "@primer/css": "^15.2.0",
     "prettier": "^2.1.2",
-    "stylelint-config-prettier": "^8.0.2",
-    "stylelint-config-primer": "^9.2.1",
-    "stylelint-prettier": "^1.1.2",
+    "stylelint-config-prettier": "^9.0.3",
+    "stylelint-config-primer": "^12.6.1",
+    "stylelint-prettier": "^2.0.0",
     "stylelint-selector-no-utility": "^4.0.0"
   },
   "scripts": {


### PR DESCRIPTION
This is to resolve #369 and only pertains to dependencies in the docs folder.  This will remain a draft PR until I find a suitable means of testing this sort of update.