### PR TITLE
Fix Plugin Doc Table

### DIFF
--- a/docs/docs/plugins/gen_protobuf.md
+++ b/docs/docs/plugins/gen_protobuf.md
@@ -31,9 +31,9 @@ Protobuf messages will only be generated for data structures identified as inter
 # Protobuf 3 Features
 
 Feature Implementation:
-| Feature | Implementation Status |
-|---------|-------------|
 
+| Feature | Implementation Status |
+|---------|-----------------------|
 | [Scalar Values](#scalar-values) | ✅ Implemented |
 | [User-defined Message Types](#user-defined-message-types) | ✅ Implemented |
 | [Embedded Comments](#embedded-comments) | ✅ Implemented |


### PR DESCRIPTION
Fixed table rendering issue (for real). I used an online Kramdown renderer to discover that the preceeding `Feature Implementation:` is disrupting the table rendering and that this change does infact render the table correctly in kramdown.