### PR TITLE
Alexcmonnet/clean up the plantuml 381

### DIFF
--- a/.vscode/python.code-workspace
+++ b/.vscode/python.code-workspace
@@ -120,7 +120,8 @@
             "program": "${workspaceFolder}/src/aac/__main__.py",
             "args": [
                 "puml-component",
-                "${workspaceFolder}/model/flow/System.yaml"
+                "${workspaceFolder}/model/flow/System.yaml",
+                "out"
             ],
             "console": "integratedTerminal",
             "justMyCode": false
@@ -131,7 +132,8 @@
             "program": "${workspaceFolder}/src/aac/__main__.py",
             "args": [
                 "puml-object",
-                "${workspaceFolder}/model/flow/System.yaml"
+                "${workspaceFolder}/model/flow/System.yaml",
+                "out"
             ],
             "console": "integratedTerminal",
             "justMyCode": false
@@ -142,7 +144,8 @@
             "program": "${workspaceFolder}/src/aac/__main__.py",
             "args": [
                 "puml-object",
-                "${workspaceFolder}/model/flow/flow.yaml"
+                "${workspaceFolder}/model/flow/flow.yaml",
+                "out"
             ],
             "console": "integratedTerminal",
             "justMyCode": false

--- a/python/src/aac/plugins/gen_plant_uml/gen_plant_uml_impl.py
+++ b/python/src/aac/plugins/gen_plant_uml/gen_plant_uml_impl.py
@@ -270,7 +270,7 @@ def _get_model_content(model: Definition, defined_interfaces: set) -> dict:
 
     for component in components:
         component_type = component.get("type")
-        model_components.append(_get_model_content(active_context.get_definition_by_name(component_type), set()))
+        model_components.append(_get_model_content(active_context.get_definition_by_name(component_type), defined_interfaces))
 
     return {
         "name": model_name,

--- a/python/src/aac/plugins/gen_plant_uml/templates/component/component_diagram.puml.jinja2
+++ b/python/src/aac/plugins/gen_plant_uml/templates/component/component_diagram.puml.jinja2
@@ -1,29 +1,31 @@
 {%- macro space(count) -%}{% for i in range(0, count)%}  {% endfor %}{%- endmacro -%}
-{%- macro print_components(model, indent_level) -%}
-{% if model.components|length > 0 %}
+{%- macro print_components(model, indent_level) %}
+{%- for interface in model.interfaces -%}
+{{space(indent_level)}}interface {{interface}}
+{% endfor -%}
+{%- if model.components|length > 0 %}
 {{space(indent_level)}}component "{{model.name}}" {
 {% for component in model.components -%}
 {{print_components(component, indent_level + 1)}}
 {% endfor -%}
 {{space(indent_level)}}}
-
 {% else -%}
 {{space(indent_level)}}component "{{model.name}}"
 {% endif -%}
 
 {%- for input in model.inputs -%}
-{{space(indent_level)}}{{input.type}} -> {{input.target}} : {{input.name}}
+{{space(indent_level)}}{{input.type}} --> {{input.target}} : {{input.name}}
 {% endfor -%}
 
 {%- for output in model.outputs -%}
-{{space(indent_level)}}{{output.source}} -> {{output.type}} : {{output.name}}
+{{space(indent_level)}}{{output.source}} --> {{output.type}} : {{output.name}}
 {% endfor -%}
-
 {%- endmacro -%}
 
 @startuml {{title}} Component Diagram
 title {{title}} Component Diagram
+
 {% for model in models -%}
 {{print_components(model, 0)}}
-{%- endfor -%}
+{%- endfor %}
 @enduml

--- a/python/tests/plugins/test_gen_plant_uml.py
+++ b/python/tests/plugins/test_gen_plant_uml.py
@@ -30,15 +30,15 @@ class TestGenPlantUml(ActiveContextTestCase):
         self.assertEqual(_get_formatted_definition_name("Definition Name"), "definition_name")
         self.assertEqual(
             _get_formatted_definition_name(f"{FILE_NAME_CHARACTERS_TO_REPLACE}This is my Definition Name"),
-            "this_is_my_definition_name"
+            "this_is_my_definition_name",
         )
         self.assertEqual(
             _get_formatted_definition_name(f"This is my{FILE_NAME_CHARACTERS_TO_REPLACE} Definition Name"),
-            "this_is_my_definition_name"
+            "this_is_my_definition_name",
         )
         self.assertEqual(
             _get_formatted_definition_name(f"This is my Definition Name{FILE_NAME_CHARACTERS_TO_REPLACE}"),
-            "this_is_my_definition_name"
+            "this_is_my_definition_name",
         )
 
     def test_generated_file_name(self):
@@ -57,12 +57,16 @@ class TestGenPlantUml(ActiveContextTestCase):
             )
             self.assertEqual(
                 _get_generated_file_name(filename, puml_type, definition_name, new_relative_dir),
-                os.path.join(new_relative_dir, puml_type, f"{file_name}_{formatted_definition_name}{PLANT_UML_FILE_EXTENSION}"),
+                os.path.join(
+                    new_relative_dir, puml_type, f"{file_name}_{formatted_definition_name}{PLANT_UML_FILE_EXTENSION}"
+                ),
             )
 
     def test_puml_component_diagram_to_file(self):
-        with (TemporaryDirectory() as temp_directory,
-              temporary_test_file(TEST_PUML_ARCH_YAML, dir=temp_directory, suffix=YAML_FILE_EXTENSION) as plugin_yaml):
+        with TemporaryDirectory() as temp_directory, temporary_test_file(
+            TEST_PUML_ARCH_YAML, dir=temp_directory, suffix=YAML_FILE_EXTENSION
+        ) as plugin_yaml:
+
             result = puml_component(plugin_yaml.name, temp_directory)
 
             full_output_dir = os.path.join(temp_directory, COMPONENT_STRING)
@@ -83,8 +87,10 @@ class TestGenPlantUml(ActiveContextTestCase):
                 check_generated_file_contents(path, self._get_checker_from_filepath(parts[-1], COMPONENT_STRING))
 
     def test_puml_object_diagram_to_file(self):
-        with (TemporaryDirectory() as temp_directory,
-              temporary_test_file(TEST_PUML_ARCH_YAML, dir=temp_directory, suffix=YAML_FILE_EXTENSION) as plugin_yaml):
+        with TemporaryDirectory() as temp_directory, temporary_test_file(
+            TEST_PUML_ARCH_YAML, dir=temp_directory, suffix=YAML_FILE_EXTENSION
+        ) as plugin_yaml:
+
             full_output_dir = os.path.join(temp_directory, OBJECT_STRING)
 
             result = puml_object(plugin_yaml.name, temp_directory)
@@ -101,8 +107,10 @@ class TestGenPlantUml(ActiveContextTestCase):
                 self._check_object_diagram_content(generated_puml_file.read())
 
     def test_puml_sequence_diagram_to_file(self):
-        with (TemporaryDirectory() as temp_directory,
-              temporary_test_file(TEST_PUML_ARCH_YAML, dir=temp_directory, suffix=YAML_FILE_EXTENSION) as plugin_yaml):
+        with TemporaryDirectory() as temp_directory, temporary_test_file(
+            TEST_PUML_ARCH_YAML, dir=temp_directory, suffix=YAML_FILE_EXTENSION
+        ) as plugin_yaml:
+
             result = puml_sequence(plugin_yaml.name, temp_directory)
 
             full_output_dir = os.path.join(temp_directory, SEQUENCE_STRING)
@@ -137,6 +145,7 @@ class TestGenPlantUml(ActiveContextTestCase):
             The method on self that checks the generated content for the file from which path was
             extracted.
         """
+
         def is_checker(obj):
             return inspect.ismethod(obj) and obj.__name__.startswith(f"_check_{puml_type}_diagram")
 
@@ -147,21 +156,29 @@ class TestGenPlantUml(ActiveContextTestCase):
         self._assert_diagram_contains_uml_boilerplate(component_diagram_content_string)
         self._check_component_diagram_serviceone(component_diagram_content_string)
         self._check_component_diagram_servicetwo(component_diagram_content_string)
-        self.assertIn(f"component \"{TEST_PUML_SYSTEM_TYPE}\"", component_diagram_content_string)
+        self.assertIn(f'component "{TEST_PUML_SYSTEM_TYPE}"', component_diagram_content_string)
 
     def _check_component_diagram_serviceone(self, component_diagram_content_string: str):
         self._assert_diagram_contains_uml_boilerplate(component_diagram_content_string)
-        self._assert_component_diagram_relations(component_diagram_content_string, "->", [
-            {"left": TEST_PUML_DATA_A_TYPE, "right": f"{TEST_PUML_SERVICE_ONE_TYPE}", "name": "in"},
-            {"left": f"{TEST_PUML_SERVICE_ONE_TYPE}", "right": TEST_PUML_DATA_B_TYPE, "name": "out"},
-        ])
+        self._assert_component_diagram_relations(
+            component_diagram_content_string,
+            "-->",
+            [
+                {"left": TEST_PUML_DATA_A_TYPE, "right": f"{TEST_PUML_SERVICE_ONE_TYPE}", "name": "in"},
+                {"left": f"{TEST_PUML_SERVICE_ONE_TYPE}", "right": TEST_PUML_DATA_B_TYPE, "name": "out"},
+            ],
+        )
 
     def _check_component_diagram_servicetwo(self, component_diagram_content_string: str):
         self._assert_diagram_contains_uml_boilerplate(component_diagram_content_string)
-        self._assert_component_diagram_relations(component_diagram_content_string, "->", [
-            {"left": TEST_PUML_DATA_B_TYPE, "right": f"{TEST_PUML_SERVICE_TWO_TYPE}", "name": "in"},
-            {"left": f"{TEST_PUML_SERVICE_TWO_TYPE}", "right": TEST_PUML_DATA_C_TYPE, "name": "out"},
-        ])
+        self._assert_component_diagram_relations(
+            component_diagram_content_string,
+            "-->",
+            [
+                {"left": TEST_PUML_DATA_B_TYPE, "right": f"{TEST_PUML_SERVICE_TWO_TYPE}", "name": "in"},
+                {"left": f"{TEST_PUML_SERVICE_TWO_TYPE}", "right": TEST_PUML_DATA_C_TYPE, "name": "out"},
+            ],
+        )
 
     def _assert_component_diagram_relations(self, content: str, relation: str, links: list[dict[str, str]]):
         for link in links:
@@ -169,13 +186,17 @@ class TestGenPlantUml(ActiveContextTestCase):
 
     def _check_object_diagram_content(self, object_diagram_content_string: str):
         self._assert_diagram_contains_uml_boilerplate(object_diagram_content_string)
-        self._assert_object_diagram_object(object_diagram_content_string, [
-            TEST_PUML_SYSTEM_TYPE, TEST_PUML_SERVICE_ONE_TYPE, TEST_PUML_SERVICE_TWO_TYPE
-        ])
-        self._assert_object_diagram_object_relations(object_diagram_content_string, "*--", [
-            {"left": TEST_PUML_SYSTEM_TYPE, "right": TEST_PUML_SERVICE_ONE_TYPE},
-            {"left": TEST_PUML_SYSTEM_TYPE, "right": TEST_PUML_SERVICE_TWO_TYPE},
-        ])
+        self._assert_object_diagram_object(
+            object_diagram_content_string, [TEST_PUML_SYSTEM_TYPE, TEST_PUML_SERVICE_ONE_TYPE, TEST_PUML_SERVICE_TWO_TYPE]
+        )
+        self._assert_object_diagram_object_relations(
+            object_diagram_content_string,
+            "*--",
+            [
+                {"left": TEST_PUML_SYSTEM_TYPE, "right": TEST_PUML_SERVICE_ONE_TYPE},
+                {"left": TEST_PUML_SYSTEM_TYPE, "right": TEST_PUML_SERVICE_TWO_TYPE},
+            ],
+        )
 
     def _assert_object_diagram_object(self, content: str, objects: list[str]):
         for obj in objects:
@@ -188,27 +209,39 @@ class TestGenPlantUml(ActiveContextTestCase):
     def _check_sequence_diagram_usecase_one(self, sequence_diagram_content_string: str):
         self._assert_diagram_contains_uml_boilerplate(sequence_diagram_content_string)
         self.assertIn(f"title {TEST_PUML_USE_CASE_ONE_TITLE}", sequence_diagram_content_string)
-        self._assert_sequence_diagram_participants(sequence_diagram_content_string, [
-            {"name": TEST_PUML_SYSTEM_NAME, "type": TEST_PUML_SYSTEM_TYPE},
-            {"name": TEST_PUML_SERVICE_ONE_NAME, "type": TEST_PUML_SERVICE_ONE_TYPE},
-            {"name": TEST_PUML_SERVICE_TWO_NAME, "type": TEST_PUML_SERVICE_TWO_TYPE},
-        ])
-        self._assert_sequence_diagram_io(sequence_diagram_content_string, [
-            {"in": TEST_PUML_SYSTEM_NAME, "out": TEST_PUML_SERVICE_ONE_NAME},
-            {"in": TEST_PUML_SERVICE_TWO_NAME, "out": TEST_PUML_SYSTEM_NAME},
-        ])
+        self._assert_sequence_diagram_participants(
+            sequence_diagram_content_string,
+            [
+                {"name": TEST_PUML_SYSTEM_NAME, "type": TEST_PUML_SYSTEM_TYPE},
+                {"name": TEST_PUML_SERVICE_ONE_NAME, "type": TEST_PUML_SERVICE_ONE_TYPE},
+                {"name": TEST_PUML_SERVICE_TWO_NAME, "type": TEST_PUML_SERVICE_TWO_TYPE},
+            ],
+        )
+        self._assert_sequence_diagram_io(
+            sequence_diagram_content_string,
+            [
+                {"in": TEST_PUML_SYSTEM_NAME, "out": TEST_PUML_SERVICE_ONE_NAME},
+                {"in": TEST_PUML_SERVICE_TWO_NAME, "out": TEST_PUML_SYSTEM_NAME},
+            ],
+        )
 
     def _check_sequence_diagram_usecase_two(self, sequence_diagram_content_string: str):
         self._assert_diagram_contains_uml_boilerplate(sequence_diagram_content_string)
         self.assertIn(f"title {TEST_PUML_USE_CASE_TWO_TITLE}", sequence_diagram_content_string)
-        self._assert_sequence_diagram_participants(sequence_diagram_content_string, [
-            {"name": TEST_PUML_SERVICE_ONE_NAME, "type": TEST_PUML_SERVICE_ONE_TYPE},
-            {"name": TEST_PUML_SERVICE_TWO_NAME, "type": TEST_PUML_SERVICE_TWO_TYPE},
-        ])
-        self._assert_sequence_diagram_io(sequence_diagram_content_string, [
-            {"in": TEST_PUML_SERVICE_ONE_NAME, "out": TEST_PUML_SERVICE_TWO_NAME},
-            {"in": TEST_PUML_SERVICE_TWO_NAME, "out": TEST_PUML_SERVICE_ONE_NAME},
-        ])
+        self._assert_sequence_diagram_participants(
+            sequence_diagram_content_string,
+            [
+                {"name": TEST_PUML_SERVICE_ONE_NAME, "type": TEST_PUML_SERVICE_ONE_TYPE},
+                {"name": TEST_PUML_SERVICE_TWO_NAME, "type": TEST_PUML_SERVICE_TWO_TYPE},
+            ],
+        )
+        self._assert_sequence_diagram_io(
+            sequence_diagram_content_string,
+            [
+                {"in": TEST_PUML_SERVICE_ONE_NAME, "out": TEST_PUML_SERVICE_TWO_NAME},
+                {"in": TEST_PUML_SERVICE_TWO_NAME, "out": TEST_PUML_SERVICE_ONE_NAME},
+            ],
+        )
 
     def _assert_sequence_diagram_participants(self, content: str, participants: list[dict[str, str]]):
         for participant in participants:


### PR DESCRIPTION
Closes #381 

* Interfaces are no-longer duplicated and positioned before the first component that references them
* Changed component arrow reference to '-->' for better rendering flexibility.

New Output:
```puml
@startuml System Component Diagram
title System Component Diagram

interface UserRequest
interface DataD

component "System" {
  interface DataB
  component "ServiceOne"
  UserRequest --> ServiceOne : in
  ServiceOne --> DataB : out

  interface DataC

  component "Subsystem" {
    component "ServiceTwo"
    DataB --> ServiceTwo : in
    ServiceTwo --> DataC : out

  }
  DataB --> Subsystem : in
  Subsystem --> DataC : out

  component "ServiceThree"
  DataC --> ServiceThree : in
  ServiceThree --> DataD : out

}
UserRequest --> System : in
System --> DataD : out

@enduml
```
![system-puml](https://user-images.githubusercontent.com/60155541/178162763-8f6fe1ae-c7b8-4ce4-981a-e11bc6213bf4.svg)

```puml
@startuml Subsystem Component Diagram
title Subsystem Component Diagram

interface DataB
interface DataC

component "Subsystem" {
  component "ServiceTwo"
  DataB --> ServiceTwo : in
  ServiceTwo --> DataC : out

}
DataB --> Subsystem : in
Subsystem --> DataC : out

@enduml
```
![subsys-puml](https://user-images.githubusercontent.com/60155541/178162764-5295e669-ff7f-4da8-9d89-7a943b5b51d6.svg)

