### PR TITLE
Added python version check

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -32,7 +32,7 @@ runtime_dependencies = [
     "starlette >= 0.19",
     "anyio < 5, >= 3.4.0",
     "sniffio >= 1.1",
-    "uvicorn >= 0.17.0",
+    "uvicorn >= 0.17.6",
     "requests >= 2.27.0"
 ]
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -32,7 +32,7 @@ runtime_dependencies = [
     "starlette >= 0.19",
     "anyio < 5, >= 3.4.0",
     "sniffio >= 1.1",
-    "uvicorn >= 0.17.6",
+    "uvicorn >= 0.17.0",
     "requests >= 2.27.0"
 ]
 

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -2,8 +2,11 @@
 
 # Run Python3.9 Check before continuing
 import sys
+
 if sys.version_info < (3, 9):
-    print("AaC requires at least Python version 3.9 or higher to run.")
+    minor = sys.version_info.minor
+    major = sys.version_info.major
+    print(f"Python version {major}.{minor} is too low; AaC requires at least Python version 3.9 or higher to run.")
     exit(1)
 
 import logging

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -1,5 +1,11 @@
 """The Architecture-as-Code tool."""
 
+# Run Python3.9 Check before continuing
+import sys
+if sys.version_info < (3, 9):
+    print("AaC requires at least Python version 3.9 or higher to run.")
+    exit(1)
+
 import logging
 import os
 


### PR DESCRIPTION
Added an initialization check for python version 3.9 or greater or it quits with an error message. 

Installing from source with pip will return the error:
```
root@322912982d3b:/python# pip install .
Processing /python
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-qe8jd_fr/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-qe8jd_fr/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-h6e6ltvk
         cwd: /tmp/pip-req-build-qe8jd_fr/
    Complete output (1 lines):
    Python version 3.6 is too low; AaC requires at least Python version 3.9 or higher to run.
    ----------------------------------------
```

Installing the wheel package in a 3.6 environment results in the following error when the package is run:
```
root@322912982d3b:/python# aac -h
Python version 3.6 is too low; AaC requires at least Python version 3.9 or higher to run.
```

I was able to check this by using a dockerfile to build and run the AaC package in a Python3.6 environment:

`Dockerfile`
```dockerfile
FROM python:3.6.15-slim

RUN mkdir /python
COPY ./python ./python
```

Steps to reproduce with the `Dockerfile` above in the root of the repo:
```sh
(venv) gitpod /workspace/AaC/python (python-version-check) $ python setup.py bdist_wheel
(venv) gitpod /workspace/AaC/python (python-version-check) $ cd ../ 
(venv) gitpod /workspace/AaC (python-version-check) $ docker build -t p36:1 .
(venv) gitpod /workspace/AaC (python-version-check) $ docker run -it p36:1 bash
root@34ef8da86b9c:/# cd python
root@34ef8da86b9c:/python# pip install .
## First Error Above
root@34ef8da86b9c:/python# python setup.py bdist_wheel
## Second Error Above
root@34ef8da86b9c:/python# pip install dist/aac-0.1.2-py3-none-any.whl
root@34ef8da86b9c:/python# aac -h
## Second Error Above
```