### PR TITLE
Some tests can fail due to path idiosyncrasies on MacOS versus Linux

### DIFF
--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,0 +1,16 @@
+import os
+
+from functools import wraps
+from tempfile import TemporaryDirectory
+
+
+def _temporary_directory_enter(fn):
+
+    @wraps(fn)
+    def wrapper(td: TemporaryDirectory):
+        return os.path.realpath(td.name)
+
+    return wrapper
+
+
+TemporaryDirectory.__enter__ = _temporary_directory_enter(TemporaryDirectory.__enter__)

--- a/python/tests/io_tests/test_parser.py
+++ b/python/tests/io_tests/test_parser.py
@@ -70,9 +70,9 @@ class TestParser(TestCase):
             self.check_model_name(model_echosvc_definition.structure, "EchoService", "model")
 
             # For some reason MacOS prepends /private to temporary files/directories
-            self.assertEqual(schema_message_definition.source.uri.removeprefix("/private"), import1.name)
-            self.assertEqual(enum_status_definition.source.uri.removeprefix("/private"), import2.name)
-            self.assertEqual(model_echosvc_definition.source.uri.removeprefix("/private"), test_yaml.name)
+            self.assertEqual(schema_message_definition.source.uri, import1.name)
+            self.assertEqual(enum_status_definition.source.uri, import2.name)
+            self.assertEqual(model_echosvc_definition.source.uri, test_yaml.name)
 
             first, second, *_ = model_echosvc_definition.lexemes
             self.assertEqual(first.source, test_yaml.name)


### PR DESCRIPTION
On MacOS there is an idiosyncrasy relating to the creation of temporary directories/files where the `/tmp` directory is a symlink to `/private/tmp` (see [here][1]). The effect of this is that tests that rely on temporary files and, more specifically, checking temporary file paths will be prepended with `/private`. It seems like [this][2] offers a possible solution to the problem so that tests can pass regardless of whether they're run on Mac or Linux.

Create a cross-platform abstraction for temporary files such that it's not necessary to worry about the `/private` prefix when writing tests.

AC:

- [ ] Tests that depend on file paths (e.g. parser tests) do not require calling `some_path.removeprefix('/private')` to pass on MacOS.
  - [ ] Use the `on_setattr` or `converter` parameters to [`attrib`](https://www.attrs.org/en/stable/api.html#attr.ib), or something similar, to make sure the Rest API models that reference file URIs resolve symlinks when they're set.
  - [ ] Update `temporary_test_file` such that the yielded file's `file.name` property references the `realpath` - i.e. have it resolve symlinks before `yield`ing the file.
  - [ ] Create a wrapper/decorator/etc around `TemporaryDirectory` that resolves symlinks before returning the directory string.
- [ ] Tests pass on Linux/Windows.

Notes:

I've determined that using resolving symlinks should address this. As such, while it wouldn't cover all cases/errors consider . Also, update `temporary_test_file` 

[1]: https://apple.stackexchange.com/questions/1043/why-is-tmp-a-symlink-to-private-tmp
[2]: https://stackoverflow.com/questions/58719364/tempfile-mkdtemp-difference-on-osx