### PR TITLE
Added in help_dump sorting for the output JSON dump

### DIFF
--- a/python/src/aac/plugins/help_dump/help_dump_impl.py
+++ b/python/src/aac/plugins/help_dump/help_dump_impl.py
@@ -30,4 +30,4 @@ def help_dump() -> PluginExecutionResult:
 def _get_all_commands() -> list[AacCommand]:
     all_plugins = plugin_manager.get_plugin_manager().get_plugins()
     list_plugins = list(flatten([plugin.get_commands() for plugin in all_plugins if hasattr(plugin, "get_commands")]))
-      return sorted(list_plugins)
+    return sorted(list_plugins)

--- a/python/src/aac/plugins/help_dump/help_dump_impl.py
+++ b/python/src/aac/plugins/help_dump/help_dump_impl.py
@@ -27,7 +27,7 @@ def help_dump() -> PluginExecutionResult:
     with plugin_result(plugin_name, get_command_info) as result:
         return result
 
-
 def _get_all_commands() -> list[AacCommand]:
     all_plugins = plugin_manager.get_plugin_manager().get_plugins()
-    return list(flatten([plugin.get_commands() for plugin in all_plugins if hasattr(plugin, "get_commands")]))
+    list_plugins = list(flatten([plugin.get_commands() for plugin in all_plugins if hasattr(plugin, "get_commands")]))
+    return sorted(list_plugins)

--- a/python/src/aac/plugins/help_dump/help_dump_impl.py
+++ b/python/src/aac/plugins/help_dump/help_dump_impl.py
@@ -31,4 +31,4 @@ def help_dump() -> PluginExecutionResult:
 def _get_all_commands() -> list[AacCommand]:
     all_plugins = plugin_manager.get_plugin_manager().get_plugins()
     list_plugins = list(flatten([plugin.get_commands() for plugin in all_plugins if hasattr(plugin, "get_commands")]))
-    return sorted(list_plugins)
+    return sorted(list_plugins, key=lambda command: command.name)

--- a/python/src/aac/plugins/help_dump/help_dump_impl.py
+++ b/python/src/aac/plugins/help_dump/help_dump_impl.py
@@ -27,6 +27,7 @@ def help_dump() -> PluginExecutionResult:
     with plugin_result(plugin_name, get_command_info) as result:
         return result
 
+
 def _get_all_commands() -> list[AacCommand]:
     all_plugins = plugin_manager.get_plugin_manager().get_plugins()
     list_plugins = list(flatten([plugin.get_commands() for plugin in all_plugins if hasattr(plugin, "get_commands")]))

--- a/python/src/aac/plugins/help_dump/help_dump_impl.py
+++ b/python/src/aac/plugins/help_dump/help_dump_impl.py
@@ -30,4 +30,4 @@ def help_dump() -> PluginExecutionResult:
 def _get_all_commands() -> list[AacCommand]:
     all_plugins = plugin_manager.get_plugin_manager().get_plugins()
     list_plugins = list(flatten([plugin.get_commands() for plugin in all_plugins if hasattr(plugin, "get_commands")]))
-    return sorted(list_plugins)
+      return sorted(list_plugins)

--- a/python/src/aac/plugins/help_dump/help_dump_impl.py
+++ b/python/src/aac/plugins/help_dump/help_dump_impl.py
@@ -30,5 +30,5 @@ def help_dump() -> PluginExecutionResult:
 
 def _get_all_commands() -> list[AacCommand]:
     all_plugins = plugin_manager.get_plugin_manager().get_plugins()
-    list_plugins = list(flatten([plugin.get_commands() for plugin in all_plugins if hasattr(plugin, "get_commands")]))
-    return sorted(list_plugins, key=lambda command: command.name)
+    plugins_with_commands = list(flatten([plugin.get_commands() for plugin in all_plugins if hasattr(plugin, "get_commands")]))
+    return sorted(plugins_with_commands, key=lambda command: command.name)

--- a/python/tests/plugins/test_help_dump_impl.py
+++ b/python/tests/plugins/test_help_dump_impl.py
@@ -37,6 +37,12 @@ class TestHelpDump(TestCase):
                 result.get_messages_as_string()
             )
 
+    def test_help_dump_json_dump_sort(self):
+        list_all_plugins = help_dump().messages
+        output_test = json.loads("".join(list_all_plugins), object_pairs_hook=OrderedDict)
+
+
+
     def expected_formatted_output(self, name, description, arguments):
         return {
             "name": name,

--- a/python/tests/plugins/test_help_dump_impl.py
+++ b/python/tests/plugins/test_help_dump_impl.py
@@ -39,7 +39,7 @@ class TestHelpDump(TestCase):
 
     def test_help_dump_json_dump_sort(self):
         list_all_plugins = help_dump().messages
-        output_test = json.loads("".join(list_all_plugins), object_pairs_hook=OrderedDict)
+        json.loads("".join(list_all_plugins), object_pairs_hook=OrderedDict)
 
     def expected_formatted_output(self, name, description, arguments):
         return {

--- a/python/tests/plugins/test_help_dump_impl.py
+++ b/python/tests/plugins/test_help_dump_impl.py
@@ -1,7 +1,7 @@
 import json
 
 from unittest import TestCase
-
+from collections import OrderedDict
 from aac.cli.aac_command import AacCommand, AacCommandArgument
 from aac.cli.aac_command_encoder import AacCommandEncoder, AacCommandArgumentEncoder
 from aac.plugins.help_dump.help_dump_impl import help_dump, _get_all_commands

--- a/python/tests/plugins/test_help_dump_impl.py
+++ b/python/tests/plugins/test_help_dump_impl.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from aac.cli.aac_command import AacCommand, AacCommandArgument
 from aac.cli.aac_command_encoder import AacCommandEncoder, AacCommandArgumentEncoder
 from aac.plugins.help_dump.help_dump_impl import help_dump, _get_all_commands
+from aac.plugins.plugin_manager import get_plugin_commands
 
 from tests.helpers.assertion import assert_plugin_success
 

--- a/python/tests/plugins/test_help_dump_impl.py
+++ b/python/tests/plugins/test_help_dump_impl.py
@@ -38,9 +38,15 @@ class TestHelpDump(TestCase):
             )
 
     def test_help_dump_json_dump_sort(self):
-        list_all_plugins = help_dump().messages
-        json.loads("".join(list_all_plugins), object_pairs_hook=OrderedDict)
+        expected_commands = sorted(get_plugin_commands(), key=lambda command: command.name)
 
+        list_all_plugins = help_dump().messages
+        help_dump_output = json.loads("".join(list_all_plugins), object_pairs_hook=OrderedDict)
+
+        expected_result = [command.name for command in expected_commands]
+        actual_result = [command.get("name") for command in help_dump_output]
+
+        self.assertListEqual(expected_result, actual_result)
     def expected_formatted_output(self, name, description, arguments):
         return {
             "name": name,

--- a/python/tests/plugins/test_help_dump_impl.py
+++ b/python/tests/plugins/test_help_dump_impl.py
@@ -41,8 +41,6 @@ class TestHelpDump(TestCase):
         list_all_plugins = help_dump().messages
         output_test = json.loads("".join(list_all_plugins), object_pairs_hook=OrderedDict)
 
-
-
     def expected_formatted_output(self, name, description, arguments):
         return {
             "name": name,

--- a/python/tests/plugins/test_help_dump_impl.py
+++ b/python/tests/plugins/test_help_dump_impl.py
@@ -47,6 +47,7 @@ class TestHelpDump(TestCase):
         actual_result = [command.get("name") for command in help_dump_output]
 
         self.assertListEqual(expected_result, actual_result)
+
     def expected_formatted_output(self, name, description, arguments):
         return {
             "name": name,


### PR DESCRIPTION
This PR is in relation to this issue -> [Issue #313](https://github.com/jondavid-black/AaC/issues/313)
Added a sort function to the help_dump results. 


The results should be sorted by alphabetical order now. 

Also added a test case for this, and as of the last testing that was done the test was passing. 

Let me know if there is anything else that is needing to be added/changed regarding this item