### PR TITLE
Extend the VSCode tests timeout

### DIFF
--- a/vscode_extension/src/test/suite/index.ts
+++ b/vscode_extension/src/test/suite/index.ts
@@ -6,7 +6,8 @@ export function run(): Promise<void> {
     // Create the mocha test
     const mocha = new Mocha({
         ui: 'tdd',
-        color: true
+        color: true,
+        timeout: 5000,
     });
 
     const testsRoot = path.resolve(__dirname, '..');


### PR DESCRIPTION
The AaC tool's startup time has grown enough to where tests fail somewhat
consistently due to timeouts to increase the timeout until we can decrease the
startup time.