### PR TITLE
Add an exception that handles template errors

### DIFF
--- a/python/src/aac/plugins/plugin_execution.py
+++ b/python/src/aac/plugins/plugin_execution.py
@@ -104,7 +104,10 @@ def plugin_result(name: str, cmd: Callable, *args: Tuple[Any], **kwargs: dict[st
         # Extract the first stack trace, skipping the plugin result we'd expect to find in the first element
         error_trace = extract_tb(error.__traceback__)[1]
         result.add_messages(
-            f"An unrecognized error occurred:{error_trace.filename} line {error_trace.lineno} message: {error}"
+            f"A(n) {error.__class__.__qualname__} error occurred",
+            f"  in {error_trace.filename}",
+            f"  on line {error_trace.lineno}",
+            f"\nThe error was:\n{error}",
         )
         result.status_code = PluginExecutionStatusCode.GENERAL_FAILURE
 

--- a/python/src/aac/plugins/plugin_execution.py
+++ b/python/src/aac/plugins/plugin_execution.py
@@ -8,6 +8,7 @@ from traceback import extract_tb
 
 from aac.io.parser import ParserError
 from aac.plugins import PluginError, OperationCancelled
+from aac.templates.error import AacTemplateError
 from aac.validate import ValidationError
 
 
@@ -90,6 +91,9 @@ def plugin_result(name: str, cmd: Callable, *args: Tuple[Any], **kwargs: dict[st
     except FileNotFoundError as error:
         result.add_messages(f"{error.strerror}: {error.filename}")
         result.status_code = PluginExecutionStatusCode.GENERAL_FAILURE
+    except AacTemplateError as error:
+        result.add_messages(error.message)
+        result.status_code = PluginExecutionStatusCode.PLUGIN_FAILURE
     except PluginError as error:
         result.set_messages(error.message)
         result.status_code = PluginExecutionStatusCode.PLUGIN_FAILURE

--- a/python/src/aac/templates/engine.py
+++ b/python/src/aac/templates/engine.py
@@ -1,10 +1,13 @@
 """This module provides a common set of templating and generation functions."""
+
 from __future__ import annotations
-from attr import attrib, attrs, validators
-from jinja2 import Environment, PackageLoader, Template
 import os
 
+from attr import attrib, attrs, validators
+from jinja2 import Environment, PackageLoader, Template, TemplateError
+
 from aac.io.writer import write_file
+from aac.templates.error import AacTemplateError
 
 
 def load_templates(package_name: str, template_directory: str = "templates") -> list[Template]:
@@ -100,7 +103,10 @@ def generate_template_as_string(template: Template, properties: dict[str, str]) 
     Returns:
         Compiled/Rendered template as a string
     """
-    return template.render(properties)
+    try:
+        return template.render(properties)
+    except TemplateError as te:
+        raise AacTemplateError(f"Error occurred during template rendering: {te.message}")
 
 
 def write_generated_templates_to_file(generated_files: list[TemplateOutputFile]) -> None:

--- a/python/src/aac/templates/engine.py
+++ b/python/src/aac/templates/engine.py
@@ -106,7 +106,7 @@ def generate_template_as_string(template: Template, properties: dict[str, str]) 
     try:
         return template.render(properties)
     except TemplateError as te:
-        raise AacTemplateError(f"Error occurred during template rendering: {te.message}")
+        raise AacTemplateError(f"Error occurred during rendering of '{template.filename}':\nThe error was: {te.message}")
 
 
 def write_generated_templates_to_file(generated_files: list[TemplateOutputFile]) -> None:

--- a/python/src/aac/templates/engine.py
+++ b/python/src/aac/templates/engine.py
@@ -136,9 +136,13 @@ def _handle_template_error(error_reason: str, callback: Callable, *args, **kwarg
     try:
         return callback(*args, **kwargs)
     except TemplateError as template_error:
+        error_message = f"{error_reason}\n{template_error}"
+
+        if hasattr(template_error, "filename"):
+            error_message = f"{error_reason}\n{os.path.basename(template_error.filename)}:L{template_error.lineno} {template_error.message}"
+
         raise AacTemplateError(
-            f"{template_error.__class__.__name__} occurred running {__package__}.{callback.__name__}:\n"
-            f"{error_reason}\n{template_error}"
+            f"{template_error.__class__.__name__} occurred running {__package__}.{callback.__name__}:\n{error_message}"
         )
 
 

--- a/python/src/aac/templates/error.py
+++ b/python/src/aac/templates/error.py
@@ -1,0 +1,16 @@
+"""A module dedicated to defining template-related errors."""
+
+
+from attr import attrib, attrs, validators
+
+
+@attrs
+class AacTemplateError(BaseException):
+    """
+    An error indicating some problem processing a template for AaC.
+
+    Attributes:
+        message (str): A message to display to the user.
+    """
+
+    message: str = attrib(validator=validators.instance_of(str))

--- a/python/tests/templates/test_engine.py
+++ b/python/tests/templates/test_engine.py
@@ -3,6 +3,7 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 from jinja2 import Template
+from jinja2.environment import Environment
 
 from aac.templates.engine import (
     TemplateOutputFile,
@@ -13,6 +14,7 @@ from aac.templates.engine import (
     write_generated_templates_to_file,
 )
 from aac.plugins.gen_plugin import __package__ as gen_plugin_package
+from aac.templates.error import AacTemplateError
 
 from tests.helpers.io import temporary_test_file
 
@@ -144,3 +146,10 @@ class TestTemplateEngine(TestCase):
 
             with open(test_file.name) as file:
                 self.assertNotEqual(file.read(), new_content)
+
+    def test_error_when_template_is_invalid(self):
+        template = Environment().from_string("{% set bad = map(attribute=x.y) %}")
+        with self.assertRaises(AacTemplateError) as cm:
+            generate_template_as_string(template, {})
+
+        self.assertRegex(cm.exception.args[0], "x.*undefined")


### PR DESCRIPTION
Closes #415

Changes:
- Add error handling to `generate_template_as_string` and `load_templates` that indicates when an error occurs when rendering or loading a template.