### PR TITLE
Opening up Reference Field Validation to be more Lenient

### DIFF
--- a/python/src/aac/plugins/validators/defined_references/_validate_references.py
+++ b/python/src/aac/plugins/validators/defined_references/_validate_references.py
@@ -23,12 +23,12 @@ def validate_references(definition_under_test: Definition, target_schema_definit
     def validate_dict(dict_to_validate: dict) -> list[str]:
 
         for reference_to_validate in validation_args:
-            dict_to_validate.get(reference_to_validate)
-            if (reference_to_validate):
-                if (language_context.is_primitive_type(reference_to_validate) or language_context.is_definition_type(reference_to_validate)):
-                    logging.debug(f"Valid type reference. Type '{reference_to_validate}' in content: {dict_to_validate}")
+            field_reference = dict_to_validate.get(reference_to_validate)
+            if (field_reference):
+                if (language_context.is_primitive_type(field_reference) or language_context.is_definition_type(field_reference)):
+                    logging.debug(f"Valid type reference. Type '{field_reference}' in content: {dict_to_validate}")
                 else:
-                    undefined_reference_error_message = f"Undefined type '{reference_to_validate}' referenced: {dict_to_validate}"
+                    undefined_reference_error_message = f"Undefined type '{field_reference}' referenced: {dict_to_validate}"
                     error_messages.append(undefined_reference_error_message)
                     logging.debug(undefined_reference_error_message)
             else:

--- a/python/src/aac/plugins/validators/defined_references/_validate_references.py
+++ b/python/src/aac/plugins/validators/defined_references/_validate_references.py
@@ -22,6 +22,7 @@ def validate_references(definition_under_test: Definition, target_schema_definit
 
     def validate_dict(dict_to_validate: dict) -> list[str]:
 
+        field_reference = ""
         for reference_to_validate in validation_args:
             field_reference = dict_to_validate.get(reference_to_validate)
             if (field_reference):

--- a/python/src/aac/plugins/validators/defined_references/_validate_references.py
+++ b/python/src/aac/plugins/validators/defined_references/_validate_references.py
@@ -19,27 +19,22 @@ def validate_references(definition_under_test: Definition, target_schema_definit
         A ValidatorResult containing any applicable error messages.
     """
     error_messages = []
-    validate_fields = validation_args
-    fields_as_list = target_schema_definition.get_top_level_fields().get("fields") or []
-    fields_as_dict = {field.get("name"): field for field in fields_as_list}
 
     def validate_dict(dict_to_validate: dict) -> list[str]:
 
-        for validate_field in validate_fields:
-            field_value = dict_to_validate.get(validate_field)
-            field_type = fields_as_dict.get(validate_field, {}).get("type")
-
-            # Verify that type is not blank
-            if field_type is None:
-                missing_type = f"Formatting error: '{validate_field}', is missing Type."
-                error_messages.append(missing_type)
-                logging.debug(missing_type)
-
-            # Verify that the name is not blank
-            elif field_value is None:
-                missing_name = f"Formatting Error: '{validate_field}' is missing a value."
-                error_messages.append(missing_name)
-                logging.debug(missing_name)
+        for reference_to_validate in validation_args:
+            dict_to_validate.get(reference_to_validate)
+            if (reference_to_validate):
+                if (language_context.is_primitive_type(reference_to_validate) or language_context.is_definition_type(reference_to_validate)):
+                    logging.debug(f"Valid type reference. Type '{reference_to_validate}' in content: {dict_to_validate}")
+                else:
+                    undefined_reference_error_message = f"Undefined type '{reference_to_validate}' referenced: {dict_to_validate}"
+                    error_messages.append(undefined_reference_error_message)
+                    logging.debug(undefined_reference_error_message)
+            else:
+                missing_field_in_dictionary = f"Missing field 'type' in validation content dictionary: {dict_to_validate}"
+                error_messages.append(missing_field_in_dictionary)
+                logging.debug(missing_field_in_dictionary)
 
     dicts_to_test = get_substructures_by_type(definition_under_test, target_schema_definition, language_context)
     list(map(validate_dict, dicts_to_test))

--- a/python/src/aac/spec/spec.yaml
+++ b/python/src/aac/spec/spec.yaml
@@ -282,10 +282,12 @@ schema:
         A description for the field to let users know what it's for and any
         other useful information.
   validation:
-    - name: Type references exist
     - name: Required fields are present
       arguments:
         - name
+        - type
+    - name: Type references exist
+      arguments:
         - type
 ---
 schema:

--- a/python/tests/plugins/validators/test_defined_references.py
+++ b/python/tests/plugins/validators/test_defined_references.py
@@ -49,7 +49,7 @@ class TestDefinedReferencesPlugin(ActiveContextTestCase):
         test_active_context = get_core_spec_context([test_invalid_schema_definition])
         field_definition = test_active_context.get_definition_by_name("Field")
 
-        actual_result = validate_references(test_invalid_schema_definition, field_definition, test_active_context)
+        actual_result = validate_references(test_invalid_schema_definition, field_definition, test_active_context, 'type')
 
         self.assertEqual(expected_result.is_valid, actual_result.is_valid)
         self.assertIn("Undefined", "\n".join(actual_result.messages))
@@ -68,7 +68,7 @@ class TestDefinedReferencesPlugin(ActiveContextTestCase):
         test_active_context = get_core_spec_context([test_invalid_schema_definition])
         field_definition = test_active_context.get_definition_by_name("Field")
 
-        actual_result = validate_references(test_invalid_schema_definition, field_definition, test_active_context)
+        actual_result = validate_references(test_invalid_schema_definition, field_definition, test_active_context, 'type')
 
         self.assertEqual(expected_result.is_valid, actual_result.is_valid)
         self.assertIn("Undefined", "\n".join(actual_result.messages))


### PR DESCRIPTION
Updated the field_references validation to be more lenient and to go based on the arguments that are passed in from the YAML instead of the hard-coded 'type'. Also added in a loop to loop through all the types to make sure they are all valid types/fields. 

Updated the test for the reference fields as well since they were failing after the tests. 
Let me know if there is anything else needed for this or if there is anything that is needing to be changed. 