### PR TITLE
Update the LanguageContext to use UUIDs as ultimate internal identifiers instead of names

### DIFF
--- a/python/src/aac/lang/definitions/definition.py
+++ b/python/src/aac/lang/definitions/definition.py
@@ -2,9 +2,7 @@
 
 import logging
 import yaml
-
 from uuid import NAMESPACE_OID, UUID, uuid5
-
 from attr import Factory, attrib, attrs, validators
 
 from aac.lang.definitions.lexeme import Lexeme

--- a/python/src/aac/lang/definitions/definition.py
+++ b/python/src/aac/lang/definitions/definition.py
@@ -1,8 +1,11 @@
 """An Architecture-as-Code definition augmented with metadata and helpful functions."""
 
-from attr import Factory, attrib, attrs, validators
 import logging
 import yaml
+
+from uuid import NAMESPACE_OID, UUID, uuid5
+
+from attr import Factory, attrib, attrs, validators
 
 from aac.lang.definitions.lexeme import Lexeme
 from aac.io.files.aac_file import AaCFile
@@ -13,6 +16,7 @@ class Definition:
     """An Architecture-as-Code definition.
 
     Attributes:
+        uid (UUID): A unique identifier for selecting the specific definition.
         name (str): The name of the definition
         content (str): The original source textual representation of the definition.
         source (AaCFile): The source document containing the definition.
@@ -20,11 +24,16 @@ class Definition:
         structure (dict): The dictionary representation of the definition.
     """
 
+    uid: UUID = attrib(init=False, validator=validators.instance_of(UUID))
     name: str = attrib(validator=validators.instance_of(str))
     content: str = attrib(validator=validators.instance_of(str))
     source: AaCFile = attrib(validator=validators.instance_of(AaCFile))
     lexemes: list[Lexeme] = attrib(default=Factory(list), validator=validators.instance_of(list))
     structure: dict = attrib(default=Factory(dict), validator=validators.instance_of(dict))
+
+    def __attrs_post_init__(self):
+        """Post-initialization hook."""
+        self.uid = uuid5(NAMESPACE_OID, self.name)
 
     def __hash__(self) -> int:
         """Return the hash of this Definition."""

--- a/python/tests/helpers/parsed_definitions.py
+++ b/python/tests/helpers/parsed_definitions.py
@@ -205,7 +205,7 @@ def create_validation_definition(name: str, description: str = "", behavior: lis
     return _create_parsed_definition("validation", definition_dict)
 
 
-def _create_parsed_definition(root_key: str, definition_structure: dict):
+def _create_parsed_definition(root_key: str, definition_structure: dict) -> Definition:
     """The base Parsed Definition creation function."""
     name = (NAME_STRING in definition_structure and definition_structure[NAME_STRING]) or "undefined_name"
     definition_dict = {root_key: definition_structure}

--- a/python/tests/lang/test_definition.py
+++ b/python/tests/lang/test_definition.py
@@ -13,6 +13,11 @@ from tests.helpers.parsed_definitions import (
 
 
 class TestDefinition(TestCase):
+    def test_uuid(self):
+        self.assertTrue(create_schema_definition("Test").uid.is_safe)
+        self.assertEqual(create_schema_definition("Test"), create_schema_definition("Test"))
+        self.assertNotEqual(create_schema_definition("Test1"), create_schema_definition("Test2"))
+
     def test_get_fields_with_empty_no_top_level_fields(self):
         test_definition = create_schema_definition("EmptyData")
         test_definition.structure["schema"] = {}

--- a/python/tests/lang/test_language_context.py
+++ b/python/tests/lang/test_language_context.py
@@ -1,10 +1,9 @@
-from unittest import TestCase
-
-from aac.lang.active_context_lifecycle_manager import get_initialized_language_context
+from aac.lang.active_context_lifecycle_manager import get_active_context, get_initialized_language_context
 from aac.lang.language_context import LanguageContext
 from aac.lang.language_error import LanguageError
 from aac.spec import get_aac_spec, get_primitives, get_root_keys
 
+from tests.active_context_test_case import ActiveContextTestCase
 from tests.helpers.parsed_definitions import (
     create_schema_definition,
     create_schema_ext_definition,
@@ -14,7 +13,7 @@ from tests.helpers.parsed_definitions import (
 )
 
 
-class TestLanguageContext(TestCase):
+class TestLanguageContext(ActiveContextTestCase):
 
     ENUM_VALUE_EXAMPLE_ONE = "valueOne"
     ENUM_VALUE_EXAMPLE_TWO = "valueTwo"
@@ -248,3 +247,9 @@ class TestLanguageContext(TestCase):
 
         self.assertRegexpMatches(str(cm.exception).lower(), "duplicate.*definition.*name.*")
         self.assertIn(self.TEST_SCHEMA_DEFINITION_NAME, str(cm.exception))
+
+    def test_uuid_in_active_context(self):
+        definition_uuids_list = [definition.uid for definition in get_active_context().definitions]
+        definition_uuids_set = set(definition_uuids_list)
+        self.assertGreaterEqual(len(definition_uuids_set), len(get_aac_spec()))
+        self.assertEqual(len(definition_uuids_list), len(definition_uuids_set))


### PR DESCRIPTION
Update the LanguageContext to use UUIDs as ultimate internal identifiers instead of names, so that users can rename definitions.

## AC:
- [x] Definition class is updated to include a private-ish field for a UUID
- [x] The Language context's dictionary "definitions_name_dictionary" is updated to use definition UUID's as keys.
- [x] The language context's `update_definition_in_context` function is updated to leverage definition UUIDs instead of names to identify previous definition versions
- [x] The language context's `add_definition_in_context` function is updated to leverage definition UUIDs instead of names to identify previous definition versions
- [x] The language context throws a LanguageError if it attempts to apply an extension to definitions with duplicate names
- [x] The language context's `remove_definition_from_context` function is updated to leverage definition UUIDs instead of names to identify previous definition versions
- [x] The language context's `get_definition_by_name` function is updated to account for the switch from definition names to UUIDS in the map key