### PR TITLE
Hotfix: Inherited Fields not Visible in Active Context

### DIFF
--- a/python/src/aac/lang/language_context.py
+++ b/python/src/aac/lang/language_context.py
@@ -69,7 +69,7 @@ class LanguageContext:
         if definition.get_inherits():
             # This import is located here because the inheritance module uses the language context for lookup, causing a circular dependency at initialization
             from aac.lang.definitions.inheritance import apply_inherited_attributes_to_definition
-            apply_inherited_attributes_to_definition(definition, self)
+            apply_inherited_attributes_to_definition(new_definition, self)
 
         if definition.is_extension():
             target_definition_name = definition.get_type()
@@ -84,7 +84,7 @@ class LanguageContext:
                     f"Duplicate definitions found ({len(definitions_with_target_definition_name)}) with name '{target_definition_name}'."
                 )
             elif target_definition:
-                apply_extension_to_definition(definition, target_definition)
+                apply_extension_to_definition(new_definition, target_definition)
             else:
                 logging.error(f"Extension failed to define target, field 'type' is missing. {definition.structure}")
 

--- a/python/src/aac/validate/_validate.py
+++ b/python/src/aac/validate/_validate.py
@@ -86,7 +86,10 @@ def _validate_definitions(definitions: list[Definition], validate_context: bool)
     context_definitions_to_validate = active_context.definitions
     definitions_to_validate = definitions + context_definitions_to_validate if validate_context else []
     [validate_each_definition(definition) for definition in definitions_to_validate]
-    return ValidatorResult(definitions, combined_findings)
+
+    # This step is necessary to return validated definitions that have had their inheritance applied.
+    validated_definitions = [active_context.get_definition_by_name(definition.name) for definition in definitions]
+    return ValidatorResult(validated_definitions, combined_findings)
 
 
 def _validate_definition(

--- a/python/tests/lang/definitions/test_inheritance.py
+++ b/python/tests/lang/definitions/test_inheritance.py
@@ -45,8 +45,9 @@ class TestDefinitionInheritance(TestCase):
         # Fields are applied when the definition is added to the context
         test_context.add_definitions_to_context([TEST_SCHEMA_PARENT_1, test_child_definition, TEST_SCHEMA_PARENT_2])
 
-        actual_validations = test_child_definition.get_validations()
-        actual_fields = test_child_definition.get_top_level_fields().get(DEFINITION_FIELD_FIELDS)
+        updated_definition = test_context.get_definition_by_name(test_child_definition.name)
+        actual_validations = updated_definition.get_validations()
+        actual_fields = updated_definition.get_top_level_fields().get(DEFINITION_FIELD_FIELDS)
 
         self.assertEqual(len(actual_validations), 2)
         field_names = [field.get(DEFINITION_FIELD_NAME) for field in actual_fields]
@@ -76,8 +77,9 @@ class TestDefinitionInheritance(TestCase):
         # Fields are applied when the definition is added to the context
         test_context.add_definitions_to_context([test_child_definition, test_parent_1_definition, test_parent_2_definition])
 
-        actual_validations = test_child_definition.get_validations()
-        actual_fields = test_child_definition.get_top_level_fields().get(DEFINITION_FIELD_FIELDS)
+        updated_definition = test_context.get_definition_by_name(test_child_definition.name)
+        actual_validations = updated_definition.get_validations()
+        actual_fields = updated_definition.get_top_level_fields().get(DEFINITION_FIELD_FIELDS)
 
         field_names = [field.get(DEFINITION_FIELD_NAME) for field in actual_fields]
         self.assertIn(TEST_SCHEMA_PARENT_1_FIELD_NAME, field_names)


### PR DESCRIPTION
* Fixed a mix-up in definitions being altered in the context resulting in inherited fields not being present in AC definitions