### PR TITLE
extended model to include requirements list

### DIFF
--- a/python/src/aac/plugins/first_party/specifications/specifications.yaml
+++ b/python/src/aac/plugins/first_party/specifications/specifications.yaml
@@ -36,7 +36,7 @@ ext:
 ---
 ext:
   name: addSpecTraceToModel
-  type: Model
+  type: model
   schemaExt:
     add:
       - name: requirements

--- a/python/src/aac/plugins/first_party/specifications/specifications.yaml
+++ b/python/src/aac/plugins/first_party/specifications/specifications.yaml
@@ -35,6 +35,14 @@ ext:
         type: Specification
 ---
 ext:
+  name: addSpecTraceToModel
+  type: Model
+  schemaExt:
+    add:
+      - name: requirements
+        type: RequirementReference
+---
+ext:
   name: addSpecTraceToBehavior
   type: Behavior
   schemaExt:


### PR DESCRIPTION
Very simple mod to allow requirements to be traced to a model.  Preserved the ability to trace requirements to a specific behavior on a model.