### PR TITLE
CLI errors don't return error codes

### DIFF
--- a/python/model/alarm_clock/alarm_clock.yaml
+++ b/python/model/alarm_clock/alarm_clock.yaml
@@ -24,6 +24,8 @@ model:
           then:
             - The alarm is triggered when the clock reaches the specified time
 ---
+import:
+  - ../alarm_clock/structures.yaml
 model:
   name: Clock
   description: A simple clock that keeps track of the current time

--- a/python/src/aac/cli/execute.py
+++ b/python/src/aac/cli/execute.py
@@ -18,7 +18,7 @@ def cli():
 @cli.result_callback()
 def output_result(result: PluginExecutionResult):
     """Output the message from the result of executing the CLI command."""
-    error_occurred = not result.is_success
+    error_occurred = not result.is_success()
     echo(result.get_messages_as_string(), err=error_occurred, color=True)
 
     get_active_context().export_to_file(ACTIVE_CONTEXT_STATE_FILE_NAME)

--- a/python/src/aac/io/parser/_parse_source.py
+++ b/python/src/aac/io/parser/_parse_source.py
@@ -217,6 +217,7 @@ def _get_files_to_process(arch_file_path: str) -> list[str]:
         for imp in root["import"]:
             arch_file_dir = path.dirname(path.realpath(arch_file_path))
             parse_path = path.join(arch_file_dir, imp.removeprefix(f".{path.sep}"))
-            files_to_import.update(_get_files_to_process(parse_path))
+            sanitized_path = sanitize_filesystem_path(parse_path)
+            files_to_import.update(_get_files_to_process(sanitized_path))
 
     return list(files_to_import)


### PR DESCRIPTION
I found that the error code for failed CLI commands wasn't being propagated to the CLI -- looks like a small error with integrating Click.

* Fixed an issue preventing the return of error codes from commands