### PR TITLE
CLI errors don't return error codes

### DIFF
--- a/.github/workflows/python-cross-platform-support.yml
+++ b/.github/workflows/python-cross-platform-support.yml
@@ -119,16 +119,6 @@ jobs:
       - name: Test Gen-Plugin Third-Party Plugin
         if: matrix.os != 'windows-latest'
         run: |
-          echo y | python -m aac gen-plugin model/plugin/plugin.yaml
-          cd model/plugin/
-          pip install .
-          aac list-plugins --active | grep test-plugin
-          aac deactivate-plugin test-plugin
-          pip uninstall -y test-plugin
-
-      - name: Test Gen-Plugin Third-Party Plugin
-        if: matrix.os == 'windows-latest'
-        run: |
           mkdir -p src/aac/plugins/third_party_test/test_plugin/
           cp model/plugin/plugin.yaml model/third_party_test/plugin.yaml
           echo y | python -m aac gen-plugin model/third_party_test/plugin.yaml
@@ -137,6 +127,8 @@ jobs:
           aac list-plugins --active | findstr "test-plugin"
           aac deactivate-plugin test-plugin
           pip uninstall -y test-plugin
+        shell:
+          bash
 
       - name: Test Gen-Plugin First-Party Plugin
         run: |

--- a/.github/workflows/python-cross-platform-support.yml
+++ b/.github/workflows/python-cross-platform-support.yml
@@ -135,7 +135,7 @@ jobs:
           mkdir -p src/aac/plugins/first_party/test_plugin/
           cp model/plugin/plugin.yaml src/aac/plugins/first_party/test_plugin/first_party.yaml
           echo y | aac gen-plugin src/aac/plugins/first_party/test_plugin/first_party.yaml
-          pip install .[all]
+          pip install .
           aac list-plugins --active | grep "test-plugin"
           aac deactivate-plugin test-plugin
         shell:

--- a/.github/workflows/python-cross-platform-support.yml
+++ b/.github/workflows/python-cross-platform-support.yml
@@ -129,8 +129,10 @@ jobs:
       - name: Test Gen-Plugin Third-Party Plugin
         if: matrix.os == 'windows-latest'
         run: |
-          echo y | python -m aac gen-plugin model/plugin/plugin.yaml
-          cd model/plugin/
+          mkdir -p src/aac/plugins/third_party_test/test_plugin/
+          cp model/plugin/plugin.yaml model/third_party_test/plugin.yaml
+          echo y | python -m aac gen-plugin model/third_party_test/plugin.yaml
+          cd model/third_party_test/
           pip install .
           aac list-plugins --active | findstr "test-plugin"
           aac deactivate-plugin test-plugin

--- a/.github/workflows/python-cross-platform-support.yml
+++ b/.github/workflows/python-cross-platform-support.yml
@@ -58,6 +58,8 @@ jobs:
             py_version: 3.9.0
           - os: ubuntu-latest
             py_version: 3.10.0
+          - os: macos-latest
+            py_version: 3.11.0
 
     steps:
       - name: Set up Python 3.9

--- a/.github/workflows/python-cross-platform-support.yml
+++ b/.github/workflows/python-cross-platform-support.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Test Gen-Plugin Third-Party Plugin
         if: matrix.os != 'windows-latest'
         run: |
-          mkdir -p src/aac/plugins/third_party_test/test_plugin/
+          mkdir -p model/third_party_test/
           cp model/plugin/plugin.yaml model/third_party_test/plugin.yaml
           echo y | python -m aac gen-plugin model/third_party_test/plugin.yaml
           cd model/third_party_test/

--- a/.github/workflows/python-cross-platform-support.yml
+++ b/.github/workflows/python-cross-platform-support.yml
@@ -135,8 +135,11 @@ jobs:
           mkdir -p src/aac/plugins/first_party/test_plugin/
           cp model/plugin/plugin.yaml src/aac/plugins/first_party/test_plugin/first_party.yaml
           echo y | aac gen-plugin src/aac/plugins/first_party/test_plugin/first_party.yaml
-          aac deactivate-plugin test-plugin
           pip install .[all]
+          aac list-plugins --active | grep "test-plugin"
+          aac deactivate-plugin test-plugin
+        shell:
+          bash
 
       - name: Upload logs from failed runs
         if: ${{ failure() }}

--- a/.github/workflows/python-cross-platform-support.yml
+++ b/.github/workflows/python-cross-platform-support.yml
@@ -124,7 +124,7 @@ jobs:
           echo y | python -m aac gen-plugin model/third_party_test/plugin.yaml
           cd model/third_party_test/
           pip install .
-          aac list-plugins --active | findstr "test-plugin"
+          aac list-plugins --active | grep "test-plugin"
           aac deactivate-plugin test-plugin
           pip uninstall -y test-plugin
         shell:

--- a/.github/workflows/python-cross-platform-support.yml
+++ b/.github/workflows/python-cross-platform-support.yml
@@ -122,8 +122,8 @@ jobs:
           echo y | python -m aac gen-plugin model/plugin/plugin.yaml
           cd model/plugin/
           pip install .
-          aac activate-plugin test-plugin
           aac list-plugins --active | grep test-plugin
+          aac deactivate-plugin test-plugin
           pip uninstall -y test-plugin
 
       - name: Test Gen-Plugin Third-Party Plugin
@@ -132,8 +132,8 @@ jobs:
           echo y | python -m aac gen-plugin model/plugin/plugin.yaml
           cd model/plugin/
           pip install .
-          aac activate-plugin test-plugin
           aac list-plugins --active | findstr "test-plugin"
+          aac deactivate-plugin test-plugin
           pip uninstall -y test-plugin
 
       - name: Test Gen-Plugin First-Party Plugin
@@ -141,6 +141,7 @@ jobs:
           mkdir -p src/aac/plugins/first_party/test_plugin/
           cp model/plugin/plugin.yaml src/aac/plugins/first_party/test_plugin/first_party.yaml
           echo y | aac gen-plugin src/aac/plugins/first_party/test_plugin/first_party.yaml
+          aac deactivate-plugin test-plugin
           pip install .[all]
 
       - name: Upload logs from failed runs

--- a/.github/workflows/python-cross-platform-support.yml
+++ b/.github/workflows/python-cross-platform-support.yml
@@ -136,6 +136,7 @@ jobs:
           cp model/plugin/plugin.yaml src/aac/plugins/first_party/test_plugin/first_party.yaml
           echo y | aac gen-plugin src/aac/plugins/first_party/test_plugin/first_party.yaml
           pip install .
+          aac list-plugins --all
           aac list-plugins --active | grep "test-plugin"
           aac deactivate-plugin test-plugin
         shell:

--- a/.github/workflows/python-cross-platform-support.yml
+++ b/.github/workflows/python-cross-platform-support.yml
@@ -136,9 +136,6 @@ jobs:
           cp model/plugin/plugin.yaml src/aac/plugins/first_party/test_plugin/first_party.yaml
           echo y | aac gen-plugin src/aac/plugins/first_party/test_plugin/first_party.yaml
           pip install .
-          aac list-plugins --all
-          aac list-plugins --active | grep "test-plugin"
-          aac deactivate-plugin test-plugin
         shell:
           bash
 

--- a/.github/workflows/python-cross-platform-support.yml
+++ b/.github/workflows/python-cross-platform-support.yml
@@ -116,13 +116,6 @@ jobs:
       - name: Create PlantUML Component Diagram
         run: python -m aac puml-object model/flow/System.yaml output/
 
-      - name: Test Gen-Plugin First-Party Plugin
-        run: |
-          mkdir -p src/aac/plugins/first_party/test_plugin/
-          cp model/plugin/plugin.yaml src/aac/plugins/first_party/test_plugin/first_party.yaml
-          echo y | aac gen-plugin src/aac/plugins/first_party/test_plugin/first_party.yaml
-          pip install .[all]
-
       - name: Test Gen-Plugin Third-Party Plugin
         if: matrix.os != 'windows-latest'
         run: |
@@ -142,6 +135,13 @@ jobs:
           aac activate-plugin test-plugin
           aac list-plugins --active | findstr "test-plugin"
           pip uninstall -y test-plugin
+
+      - name: Test Gen-Plugin First-Party Plugin
+        run: |
+          mkdir -p src/aac/plugins/first_party/test_plugin/
+          cp model/plugin/plugin.yaml src/aac/plugins/first_party/test_plugin/first_party.yaml
+          echo y | aac gen-plugin src/aac/plugins/first_party/test_plugin/first_party.yaml
+          pip install .[all]
 
       - name: Upload logs from failed runs
         if: ${{ failure() }}

--- a/.github/workflows/python-test-python-version.yml
+++ b/.github/workflows/python-test-python-version.yml
@@ -60,8 +60,8 @@ jobs:
         rm src/aac/state.json
         cd model/plugin/
         pip install .
-        aac activate-plugin test-plugin
         aac list-plugins --active | grep test-plugin
+        aac deactivate-plugin test-plugin
         pip uninstall -y test-plugin
 
     - name: Upload logs from failed runs

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(

--- a/python/src/aac/cli/execute.py
+++ b/python/src/aac/cli/execute.py
@@ -18,7 +18,7 @@ def cli():
 @cli.result_callback()
 def output_result(result: PluginExecutionResult):
     """Output the message from the result of executing the CLI command."""
-    error_occurred = not result.is_success
+    error_occurred = not result.is_success()
     echo(result.get_messages_as_string(), err=error_occurred, color=True)
 
     get_active_context().export_to_file(ACTIVE_CONTEXT_STATE_FILE_NAME)


### PR DESCRIPTION
I found that the error code for failed CLI commands wasn't being propagated to the CLI -- looks like a small error with integrating Click.

* Fixed an issue preventing the return of error codes from commands