### PR TITLE
Fixed bug 528

### DIFF
--- a/python/model/calc/spec/Add_SRS.yaml
+++ b/python/model/calc/spec/Add_SRS.yaml
@@ -4,12 +4,14 @@ import:
 spec:
   name: Module Add SRS
   description:  This is a representative Software Requirements Specification for a module called Add.
-  requirements:
-    - id: "ADD-1"
-      shall:  When receiving an add message, the calculator shall respond with the sum of the provided values.
-      parent:
-        ids:
-          - "SM-1"
-      attributes:
-        - name: TADI
-          value: Test
+  sections:
+    - name: Section about adding numbers.
+      requirements:
+        - id: "ADD-1"
+          shall:  When receiving an add message, the calculator shall respond with the sum of the provided values.
+          parent:
+            ids:
+              - "SM-1"
+          attributes:
+            - name: TADI
+              value: Test

--- a/python/src/aac/plugins/first_party/specifications/specifications_impl.py
+++ b/python/src/aac/plugins/first_party/specifications/specifications_impl.py
@@ -24,7 +24,8 @@ def spec_csv(architecture_file: str, output_directory: str) -> PluginExecutionRe
         spec_definitions = _get_parsed_models(architecture_file)
         reqs = {}
         for spec in spec_definitions:
-            reqs[spec.name] = _get_requirements(spec)
+            file_name = path.basename(spec.source.uri)
+            reqs[file_name] = _get_requirements(spec)
 
         field_names = ["Spec Name", "Section", "ID", "Requirement", "Parents", "Children"]
 
@@ -62,8 +63,9 @@ def _get_requirements(spec: Definition) -> List[dict]:
         spec_name = spec_dict["spec"]["name"]
 
         # handle the spec root requirements
-        for req in spec_dict["spec"]["requirements"]:
-            ret_val.append(_gen_spec_line_from_req_dict(spec_name, "", req))
+        if "requirements" in spec_dict["spec"].keys():
+            for req in spec_dict["spec"]["requirements"]:
+                ret_val.append(_gen_spec_line_from_req_dict(spec_name, "", req))
 
         # handle the requirements in each section
         if "sections" in spec_dict["spec"].keys():

--- a/python/src/aac/plugins/first_party/specifications/specifications_impl.py
+++ b/python/src/aac/plugins/first_party/specifications/specifications_impl.py
@@ -25,7 +25,7 @@ def spec_csv(architecture_file: str, output_directory: str) -> PluginExecutionRe
         reqs = {}
         for spec in spec_definitions:
             file_name = path.basename(spec.source.uri)
-            reqs[file_name] = _get_requirements(spec)
+            reqs[spec.name] = _get_requirements(spec)
 
         field_names = ["Spec Name", "Section", "ID", "Requirement", "Parents", "Children"]
 


### PR DESCRIPTION
Simple change to check for key prior to accessing key in dict.
Also changed the way file names are created in the spec-csv command to align directly with input file rather than a potentially long name from within the file.