### PR TITLE
Fix .aac files being opened in the visual editor

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -197,7 +197,7 @@
                 "displayName": "Edit AaC Definitions",
                 "selector": [
                     {
-                        "filenamePattern": "*.aac"
+                        "filenamePattern": "."
                     }
                 ],
                 "priority": "default"


### PR DESCRIPTION
Closes #540

Turns out the problem was mostly straightforward, though I couldn't get the visual editor to open unless I had a non-empty string in the file selector value. 

Visual of the fix:
![image](https://user-images.githubusercontent.com/60155541/231329861-f3f8c49a-4615-40be-b9b9-435a94eb62fe.png)
