### PR TITLE
Root Key Rename Duplicates Colon

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@ Include pertinent changes of fixing the bug.
 - None
 
 ### Breaking Changes
-Include pertinent changes that qualify as breaking changes. Be sure to include information about the impact to end users and additional information for addressing the break if more than a version transition is necessary for mitigating. 
+Include pertinent changes that qualify as breaking changes. Be sure to include information about the impact to end users and additional information for addressing the break if more than a version transition is necessary for mitigating.
 - None
 
 ### Feature Improvement Changes
@@ -34,3 +34,4 @@ Include pertinent changes that are improvements to existing features.
 - [ ] My changes generate no new warnings.
 - [ ] Have updated new and existing unit tests accordingly.
 - [ ] Linked associated items to be closed.
+- [ ] Have you bumped the version if there will be a release?

--- a/python/setup.py
+++ b/python/setup.py
@@ -34,7 +34,7 @@ runtime_dependencies = [
 ]
 
 development_dependencies = [
-    "wheel == 0.37.0",
+    "wheel ~= 0.40.0",
     "pip-tools >= 6.9.0",
     "tomli < 2.0.0",
     "black == 22.3.0",

--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(

--- a/python/src/aac/lang/definitions/definition.py
+++ b/python/src/aac/lang/definitions/definition.py
@@ -5,7 +5,7 @@ import logging
 import yaml
 from attr import Factory, attrib, attrs, validators
 from typing import Any, Optional
-from uuid import UUID, uuid4
+from uuid import UUID, uuid5, NAMESPACE_DNS
 
 from aac.io.files.aac_file import AaCFile
 from aac.lang.constants import (
@@ -48,7 +48,7 @@ class Definition:
 
     def __attrs_post_init__(self):
         """Post-init hook."""
-        self.uid = uuid4()
+        self.uid = uuid5(NAMESPACE_DNS, str(self.__hash__()))
 
     def __hash__(self) -> int:
         """Return the hash of this Definition."""

--- a/python/src/aac/plugins/first_party/lsp_server/providers/rename_provider.py
+++ b/python/src/aac/plugins/first_party/lsp_server/providers/rename_provider.py
@@ -173,5 +173,3 @@ class RenameProvider(LspProvider):
 def _filter_editable_definitions(definitions_to_filter: List[Definition]) -> List[Definition]:
     filtered_definitions = {definition for definition in definitions_to_filter if definition.source.is_user_editable}
     return list(filtered_definitions)
-
-

--- a/python/src/aac/plugins/first_party/lsp_server/providers/rename_provider.py
+++ b/python/src/aac/plugins/first_party/lsp_server/providers/rename_provider.py
@@ -66,11 +66,12 @@ class RenameProvider(LspProvider):
 
     def _get_rename_edits(self, symbol: str, new_name: str) -> dict[str, list[TextEdit]]:
         """Returns the list of text edits based on the selected symbol's type."""
-        language_context = self.language_server.language_context
 
         # Strip any ':' that accompany yaml keys from the incoming replacement text
         sanitized_new_name = new_name.strip(":")
-        text_to_replace = remove_list_type_indicator(symbol).strip(":")
+        text_to_replace = remove_list_type_indicator(symbol)
+
+        language_context = self.language_server.language_context
         symbol_types = get_possible_symbol_types(text_to_replace, language_context)
 
         edits = {}
@@ -172,3 +173,5 @@ class RenameProvider(LspProvider):
 def _filter_editable_definitions(definitions_to_filter: List[Definition]) -> List[Definition]:
     filtered_definitions = {definition for definition in definitions_to_filter if definition.source.is_user_editable}
     return list(filtered_definitions)
+
+

--- a/python/src/aac/plugins/first_party/lsp_server/providers/rename_provider.py
+++ b/python/src/aac/plugins/first_party/lsp_server/providers/rename_provider.py
@@ -53,9 +53,10 @@ class RenameProvider(LspProvider):
 
         if document:
             symbol = get_symbol_at_position(document.source, position.line, position.character)
-            edits = self._get_rename_edits(symbol, new_name) if symbol else {}
 
             if symbol:
+                edits = self._get_rename_edits(symbol, new_name)
+
                 try:
                     workspace_edit = WorkspaceEdit(text_document=TextDocumentIdentifier(uri=document.uri), changes=edits)
                 except Exception as error:
@@ -65,38 +66,37 @@ class RenameProvider(LspProvider):
 
     def _get_rename_edits(self, symbol: str, new_name: str) -> dict[str, list[TextEdit]]:
         """Returns the list of text edits based on the selected symbol's type."""
-        if not symbol:
-            return None
-
         language_context = self.language_server.language_context
 
-        name = remove_list_type_indicator(symbol).strip(":")
-        symbol_types = get_possible_symbol_types(name, language_context)
+        # Strip any ':' that accompany yaml keys from the incoming replacement text
+        sanitized_new_name = new_name.strip(":")
+        text_to_replace = remove_list_type_indicator(symbol).strip(":")
+        symbol_types = get_possible_symbol_types(text_to_replace, language_context)
 
         edits = {}
         if SymbolType.DEFINITION_NAME in symbol_types:
-            definition_to_find = language_context.get_definition_by_name(name)
+            definition_to_find = language_context.get_definition_by_name(text_to_replace)
             if not definition_to_find:
-                logging.warn(f"Can't find references for non-definition {name}")
+                logging.warn(f"Can't find references for non-definition {text_to_replace}")
             else:
-                edits = self._get_definition_name_text_edits(new_name, definition_to_find, language_context)
+                edits = self._get_definition_name_text_edits(sanitized_new_name, definition_to_find, language_context)
 
         if SymbolType.ENUM_VALUE_TYPE in symbol_types:
-            enum_to_find = language_context.get_enum_definition_by_type(name)
+            enum_to_find = language_context.get_enum_definition_by_type(text_to_replace)
             if not enum_to_find:
-                logging.warn(f"Can't find references for non-enum {name}")
+                logging.warn(f"Can't find references for non-enum {text_to_replace}")
             else:
-                edits = self._get_enum_value_type_text_edits(name, new_name, enum_to_find, language_context)
+                edits = self._get_enum_value_type_text_edits(text_to_replace, sanitized_new_name, enum_to_find, language_context)
 
         if SymbolType.ROOT_KEY in symbol_types:
             root_fields = language_context.get_root_fields()
-            key_schema_field, *_ = [field for field in root_fields if field.get(DEFINITION_FIELD_NAME) == name]
+            key_schema_field, *_ = [field for field in root_fields if field.get(DEFINITION_FIELD_NAME) == text_to_replace]
             definition_to_find = language_context.get_definition_by_name(key_schema_field.get(DEFINITION_FIELD_TYPE))
 
             if not definition_to_find:
-                logging.critical(f"Can't find the source definition definition '{name}'.")
+                logging.critical(f"Can't find the source definition definition '{text_to_replace}'.")
             else:
-                edits = self._get_root_key_text_edits(name, new_name, definition_to_find, language_context)
+                edits = self._get_root_key_text_edits(text_to_replace, sanitized_new_name, definition_to_find, language_context)
 
         return edits
 

--- a/python/src/aac/plugins/first_party/lsp_server/providers/symbols.py
+++ b/python/src/aac/plugins/first_party/lsp_server/providers/symbols.py
@@ -81,7 +81,7 @@ def get_symbol_range_at_position(content: str, line: int, column: int) -> Option
 
                 symbol_start = i
 
-            symbol_end = len(line_with_symbol)
+            symbol_end = len(line_with_symbol) - 1
             for i in range(adjusted_column, len(line_with_symbol)):
                 if line_with_symbol[i] == ":":
                     break

--- a/python/tests/lang/test_definition.py
+++ b/python/tests/lang/test_definition.py
@@ -14,9 +14,15 @@ from tests.helpers.parsed_definitions import (
 
 class TestDefinition(TestCase):
     def test_uuid(self):
-        self.assertTrue(create_schema_definition("Test").uid.is_safe)
-        self.assertNotEqual(create_schema_definition("Test").uid, create_schema_definition("Test").uid)
-        self.assertNotEqual(create_schema_definition("Test1").uid, create_schema_definition("Test2").uid)
+        test_definition_1 = create_schema_definition("Test1")
+        test_definition_1_alt_source = create_schema_definition("Test1")
+        test_definition_1_alt_source.source.uri = "test1File"
+
+        test_definition_2 = create_schema_definition("Test2")
+
+        self.assertTrue(test_definition_1)
+        self.assertEqual(test_definition_1.uid, test_definition_1.uid)
+        self.assertNotEqual(test_definition_1.uid, test_definition_2.uid)
 
     def test_get_fields_with_empty_no_top_level_fields(self):
         test_definition = create_schema_definition("EmptyData")

--- a/python/tests/plugins/lsp_server/providers/test_rename_provider.py
+++ b/python/tests/plugins/lsp_server/providers/test_rename_provider.py
@@ -94,6 +94,5 @@ class TestRenameProvider(BaseLspTestCase, IsolatedAsyncioTestCase):
         actual_document_edits = res.get_workspace_edit()
 
         self.assertIn(TEST_DOCUMENT_NAME, list(actual_document_edits.keys())[0])
-        print(actual_text_edits[0].get("newText"))
         self.assertEqual(expected_new_name, actual_text_edits[0].get("newText"))
         self.assertEqual(2, len(actual_text_edits))

--- a/python/tests/plugins/lsp_server/providers/test_rename_provider.py
+++ b/python/tests/plugins/lsp_server/providers/test_rename_provider.py
@@ -85,7 +85,7 @@ class TestRenameProvider(BaseLspTestCase, IsolatedAsyncioTestCase):
         self.assertIsNone(res.response)
 
     async def test_rename_request_doesnt_duplicate_colons(self):
-        """Covers bugfix #597"""
+        """Covers bugfix #597."""
         lsp_client_new_text = "DataANew:"
         expected_new_name = lsp_client_new_text.strip(":")
 

--- a/python/tests/plugins/lsp_server/providers/test_rename_provider.py
+++ b/python/tests/plugins/lsp_server/providers/test_rename_provider.py
@@ -83,3 +83,17 @@ class TestRenameProvider(BaseLspTestCase, IsolatedAsyncioTestCase):
         await self.write_document(TEST_DOCUMENT_NAME, f"\n{TEST_DOCUMENT_CONTENT}")
         res: RenameResponse = await self.rename(TEST_DOCUMENT_NAME, expected_new_name)
         self.assertIsNone(res.response)
+
+    async def test_rename_request_doesnt_duplicate_colons(self):
+        """Covers bugfix #597"""
+        lsp_client_new_text = "DataANew:"
+        expected_new_name = lsp_client_new_text.strip(":")
+
+        res: RenameResponse = await self.rename(TEST_DOCUMENT_NAME, lsp_client_new_text, 1, 8)
+        actual_text_edits = res.get_all_text_edits()
+        actual_document_edits = res.get_workspace_edit()
+
+        self.assertIn(TEST_DOCUMENT_NAME, list(actual_document_edits.keys())[0])
+        print(actual_text_edits[0].get("newText"))
+        self.assertEqual(expected_new_name, actual_text_edits[0].get("newText"))
+        self.assertEqual(2, len(actual_text_edits))


### PR DESCRIPTION
Closes #539

* Fixed the issue of duplicate colons by stripping colons in rename text provided by the LSP client
* Added uuid logic to definitions to address some duplication issues in the language context

# Evidence
Screenshots of the model root key being renamed to 'my_model' demonstrating that there is no extra colon appended to the end (e.g. `my_model::`).
![Screenshot 2023-05-01 at 11 53 56 PM](https://user-images.githubusercontent.com/60155541/235582323-35d6c623-b281-4233-b6aa-e58e91335c34.png)
![Screenshot 2023-05-01 at 11 54 20 PM](https://user-images.githubusercontent.com/60155541/235582320-c1ec54f5-2eff-461e-8dfd-fdc43c58c4d3.png)
