### PR TITLE
545 generate plugin command puts test stub in wrong directory

### DIFF
--- a/python/src/aac/plugins/first_party/gen_plugin/gen_plugin_impl.py
+++ b/python/src/aac/plugins/first_party/gen_plugin/gen_plugin_impl.py
@@ -125,7 +125,7 @@ def _get_template_output_directories(plugin_type: str, architecture_file_path: s
         "__init__.py.jinja2": architecture_file_directory_path,
     }
 
-    # Third party files are generated a level belowthe architecture file
+    # Third party files are generated a level below the architecture file
     third_party_directories = {
         "test_plugin_impl.py.jinja2": "tests",
         "README.md.jinja2": "",

--- a/python/src/aac/plugins/first_party/gen_plugin/gen_plugin_impl.py
+++ b/python/src/aac/plugins/first_party/gen_plugin/gen_plugin_impl.py
@@ -120,7 +120,7 @@ def _get_template_output_directories(plugin_type: str, architecture_file_path: s
 
     # First party files are generated at the same level as the architecture file
     first_party_directories = {
-        "test_plugin_impl.py.jinja2": path.join("tests", "plugins"),
+        "test_plugin_impl.py.jinja2": path.join("tests", "plugins", "first_party"),
         "plugin_impl.py.jinja2": architecture_file_directory_path,
         "__init__.py.jinja2": architecture_file_directory_path,
     }

--- a/python/tests/plugins/first_party/test_gen_plugin.py
+++ b/python/tests/plugins/first_party/test_gen_plugin.py
@@ -46,7 +46,7 @@ class TestGenPlugin(ActiveContextTestCase):
                 self.assertEqual(len(os.listdir(temp_directory)), 2)
 
                 # Assert the test was generated
-                generated_test_file = os.listdir(f"{temp_directory}/tests/plugins/")
+                generated_test_file = os.listdir(f"{temp_directory}/tests/plugins/first_party")
                 self.assertEqual(len(generated_test_file), 1)
                 self.assertIn(f"test_{TEST_PLUGIN_NAME}_impl.py", generated_test_file)
 


### PR DESCRIPTION
# Description
Updated the pathing for the auto generated example unit test of the `gen-plugin` command to place the unit test under `tests/plugins/first_party`

# Linked Items:
Closes #545 

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Feature improvement

### Feature Additions
- None

### Bug Fixes
- None

### Breaking Changes
- None

### Feature Improvement Changes
- Updated the pathing for placing the auto generated unit test in the expected location. 

# Checklist:
- [x] Updated documentation accordingly.
- [x] My changes generate no new warnings.
- [x] Have updated new and existing unit tests accordingly.
- [x] Linked associated items to be closed.
- [ ] Have you bumped the version if there will be a release?
