### PR TITLE
Dynamically register core plugins

### DIFF
--- a/python/src/aac/__init__.py
+++ b/python/src/aac/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 9):
 import logging
 import os
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 __log_file_name__ = os.path.join(os.path.dirname(__file__), "aac.log")
 
 logging.basicConfig(


### PR DESCRIPTION
# Description

Update the `plugin_manager` module to dynamically register core plugins, rather than hard-coding packages and plugin names.

# Linked Items:

Closes #567

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Feature improvement

### Feature Additions
Include pertinent changes as a result of adding the new feature.
- None

### Bug Fixes
Include pertinent changes of fixing the bug.
- None

### Breaking Changes
Include pertinent changes that qualify as breaking changes. Be sure to include information about the impact to end users and additional information for addressing the break if more than a version transition is necessary for mitigating.
- None

### Feature Improvement Changes
Include pertinent changes that are improvements to existing features.
- None

# Checklist:
- [ ] Updated documentation accordingly.
- [ ] My changes generate no new warnings.
- [ ] Have updated new and existing unit tests accordingly.
- [ ] Linked associated items to be closed.
- [ ] Have you bumped the version if there will be a release?